### PR TITLE
Used .at() instead of operator[] where possible

### DIFF
--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -219,7 +219,7 @@ std::optional<std::pair<unsigned long long, std::shared_ptr<Imperator::Province>
 	maxDev = -1; // We can have winning provinces with weight = 0;
 
 	std::pair<unsigned long long, std::shared_ptr<Imperator::Province>> toReturn;
-	for (const auto& province : theClaims[*winner])
+	for (const auto& province : theClaims.at(*winner))
 	{
 		const auto provinceWeight = province->getBuildingsCount() + province->getPopCount();
 

--- a/ImperatorToCK3/Source/CK3/Titles/LandedTitles.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/LandedTitles.cpp
@@ -44,8 +44,8 @@ void CK3::LandedTitles::registerKeys()
 				}
 			}
 			foundTitles[locatedTitleName] = locatedTitle;
-			if (!foundTitles[locatedTitleName]->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
-				foundTitles[locatedTitleName]->setDeJureLiege(newTitle);
+			if (!foundTitles.at(locatedTitleName)->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
+				foundTitles.at(locatedTitleName)->setDeJureLiege(newTitle);
 		}
 		// now that all titles under newTitle have been moved to main foundTitles, newTitle's foundTitles can be cleared
 		newTitle->foundTitles.clear();

--- a/ImperatorToCK3/Source/CK3/Titles/LandedTitles.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/LandedTitles.cpp
@@ -29,29 +29,7 @@ void CK3::LandedTitles::registerKeys()
 		auto newTitle = std::make_shared<Title>(titleNameStr);
 		newTitle->loadTitles(theStream);
 
-		for (const auto& [locatedTitleName, locatedTitle] : newTitle->foundTitles)
-		{
-			if (newTitle->titleName.starts_with("c_")) // has county prefix = is a county
-			{
-				auto baronyProvince = locatedTitle->getProvince();
-				if (baronyProvince)
-				{
-					if (locatedTitleName == newTitle->capitalBarony)
-					{
-						newTitle->capitalBaronyProvince = *baronyProvince;
-					}
-					newTitle->addCountyProvince(*baronyProvince); // add found baronies' provinces to countyProvinces
-				}
-			}
-			foundTitles[locatedTitleName] = locatedTitle;
-			if (!foundTitles.at(locatedTitleName)->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
-				foundTitles.at(locatedTitleName)->setDeJureLiege(newTitle);
-		}
-		// now that all titles under newTitle have been moved to main foundTitles, newTitle's foundTitles can be cleared
-		newTitle->foundTitles.clear();
-
-		// And then add this one as well, overwriting existing.
-		foundTitles[newTitle->titleName] = newTitle;
+		Title::addFoundTitle(newTitle, foundTitles);
 		});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/ImperatorToCK3/Source/CK3/Titles/Title.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/Title.cpp
@@ -1,13 +1,41 @@
 #include "Title.h"
 #include "LandedTitles.h"
 #include "TitlesHistory.h"
-#include "../../Imperator/Characters/Character.h"
 #include "../../Imperator/Countries/Country.h"
 #include "../../Mappers/ProvinceMapper/ProvinceMapper.h"
 #include "../../Mappers/CoaMapper/CoaMapper.h"
 #include "../../Mappers/TagTitleMapper/TagTitleMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+
+
+
+void CK3::Title::addFoundTitle(const std::shared_ptr<Title>& newTitle, std::map<std::string, std::shared_ptr<Title>>& foundTitles)
+{
+	for (const auto& [locatedTitleName, locatedTitle] : newTitle->foundTitles)
+	{
+		if (newTitle->titleName.starts_with("c_")) // has county prefix = is a county
+		{
+			auto baronyProvince = locatedTitle->getProvince();
+			if (baronyProvince)
+			{
+				if (locatedTitleName == newTitle->capitalBarony)
+				{
+					newTitle->capitalBaronyProvince = *baronyProvince;
+				}
+				newTitle->addCountyProvince(*baronyProvince); // add found baronies' provinces to countyProvinces
+			}
+		}
+		foundTitles[locatedTitleName] = locatedTitle;
+		if (!foundTitles.at(locatedTitleName)->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
+			foundTitles.at(locatedTitleName)->setDeJureLiege(newTitle);
+	}
+	// now that all titles under newTitle have been moved to main foundTitles, newTitle's foundTitles can be cleared
+	newTitle->foundTitles.clear();
+
+	// And then add this one as well, overwriting existing.
+	foundTitles[newTitle->titleName] = newTitle;
+}
 
 
 void CK3::Title::loadTitles(std::istream& theStream)
@@ -29,29 +57,7 @@ void CK3::Title::registerKeys()
 			capitalBarony = newTitle->titleName;
 		}
 		
-		for (auto& [locatedTitleName, locatedTitle] : newTitle->foundTitles)
-		{
-			if (newTitle->titleName.starts_with("c_")) // has county prefix = is a county
-			{
-				auto baronyProvince = locatedTitle->getProvince();
-				if (baronyProvince)
-				{
-					if (locatedTitleName == newTitle->capitalBarony)
-					{
-						newTitle->capitalBaronyProvince = *baronyProvince;
-					}
-					newTitle->addCountyProvince(*baronyProvince); // add found baronies' provinces to countyProvinces
-				}
-			}
-			foundTitles[locatedTitleName] = locatedTitle;
-			if (!foundTitles[locatedTitleName]->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
-				foundTitles[locatedTitleName]->setDeJureLiege(newTitle);
-		}
-		// now that all titles under newTitle have been moved to main foundTitles, newTitle's foundTitles can be cleared
-		newTitle->foundTitles.clear();
-
-		// And then add this one as well, overwriting existing.
-		foundTitles[newTitle->titleName] = newTitle;
+		addFoundTitle(newTitle, foundTitles);
 		});
 	registerKeyword("definite_form", [this](const std::string& unused, std::istream& theStream) {
 		definiteForm = commonItems::singleString(theStream).getString() == "yes";
@@ -72,12 +78,8 @@ void CK3::Title::registerKeys()
 }
 
 
-
-
-
-
 void CK3::Title::initializeFromTag(std::shared_ptr<Imperator::Country> theCountry, mappers::LocalizationMapper& localizationMapper, LandedTitles& landedTitles, mappers::ProvinceMapper& provinceMapper,
-	mappers::CoaMapper& coaMapper, mappers::TagTitleMapper& tagTitleMapper)
+                                   mappers::CoaMapper& coaMapper, mappers::TagTitleMapper& tagTitleMapper)
 {
 	generated = true;
 

--- a/ImperatorToCK3/Source/CK3/Titles/Title.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/Title.cpp
@@ -26,9 +26,9 @@ void CK3::Title::addFoundTitle(const std::shared_ptr<Title>& newTitle, std::map<
 				newTitle->addCountyProvince(*baronyProvince); // add found baronies' provinces to countyProvinces
 			}
 		}
+		if (!locatedTitle->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
+			locatedTitle->setDeJureLiege(newTitle);
 		foundTitles[locatedTitleName] = locatedTitle;
-		if (!foundTitles.at(locatedTitleName)->getDeJureLiege()) // locatedTitle has no de jure liege set yet, which indicated it's newTitle's direct de jure vassal
-			foundTitles.at(locatedTitleName)->setDeJureLiege(newTitle);
 	}
 	// now that all titles under newTitle have been moved to main foundTitles, newTitle's foundTitles can be cleared
 	newTitle->foundTitles.clear();

--- a/ImperatorToCK3/Source/CK3/Titles/Title.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/Title.cpp
@@ -123,7 +123,7 @@ void CK3::Title::initializeFromTag(std::shared_ptr<Imperator::Country> theCountr
 	{
 		const auto provMappingsForImperatorCapital = provinceMapper.getCK3ProvinceNumbers(*srcCapital);
 		if (!provMappingsForImperatorCapital.empty())
-			capitalCounty = landedTitles.getCountyForProvince(provMappingsForImperatorCapital[0]);
+			capitalCounty = landedTitles.getCountyForProvince(provMappingsForImperatorCapital.at(0));
 	}
 	
 
@@ -255,10 +255,10 @@ std::map<std::string, std::shared_ptr<CK3::Title>> CK3::Title::getDeFactoVassals
 
 void CK3::Title::addHistory(const LandedTitles& landedTitles, TitlesHistory& titlesHistory)
 {
-	if (const auto currentHolder = titlesHistory.currentHolderIdMap[titleName]; currentHolder)
+	if (const auto currentHolder = titlesHistory.currentHolderIdMap.at(titleName); currentHolder)
 		holder = *currentHolder;
 
-	const auto dfLiegeName = titlesHistory.currentLiegeIdMap[titleName];
+	const auto dfLiegeName = titlesHistory.currentLiegeIdMap.at(titleName);
 	if (dfLiegeName && landedTitles.getTitles().contains(*dfLiegeName))
 		setDeFactoLiege(landedTitles.getTitles().find(*dfLiegeName)->second);
 	

--- a/ImperatorToCK3/Source/CK3/Titles/Title.h
+++ b/ImperatorToCK3/Source/CK3/Titles/Title.h
@@ -78,6 +78,8 @@ class Title: commonItems::parser, public std::enable_shared_from_this<Title>
 
   private:
 	friend class LandedTitles;
+	static void addFoundTitle(const std::shared_ptr<Title>& newTitle, std::map<std::string, std::shared_ptr<Title>>& foundTitles);
+	
 	void registerKeys();
 	void trySetAdjectiveLoc(mappers::LocalizationMapper& localizationMapper);
 

--- a/ImperatorToCK3/Source/CK3/Titles/TitlesHistory.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/TitlesHistory.cpp
@@ -45,7 +45,7 @@ std::optional<std::string> CK3::TitlesHistory::popTitleHistory(const std::string
 {
 	if (historyMap.contains(titleName))
 	{
-		auto history = historyMap[titleName];
+		auto history = historyMap.at(titleName);
 		historyMap.erase("titleName");
 		return history;
 	}

--- a/ImperatorToCK3/Source/Imperator/Characters/PortraitData.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/PortraitData.cpp
@@ -10,14 +10,14 @@ Imperator::CharacterPortraitData::CharacterPortraitData(const std::string& dnaSt
 	const auto decodedDnaStr = base64_decode(dnaString);
 
 	//hair
-	hairColorPaletteCoordinates.x = static_cast<uint8_t>(decodedDnaStr[0]) * 2;
-	hairColorPaletteCoordinates.y = static_cast<uint8_t>(decodedDnaStr[1]) * 2;
+	hairColorPaletteCoordinates.x = static_cast<uint8_t>(decodedDnaStr.at(0)) * 2;
+	hairColorPaletteCoordinates.y = static_cast<uint8_t>(decodedDnaStr.at(1)) * 2;
 	//skin
-	skinColorPaletteCoordinates.x = static_cast<uint8_t>(decodedDnaStr[4]) * 2;
-	skinColorPaletteCoordinates.y = static_cast<uint8_t>(decodedDnaStr[5]) * 2;
+	skinColorPaletteCoordinates.x = static_cast<uint8_t>(decodedDnaStr.at(4)) * 2;
+	skinColorPaletteCoordinates.y = static_cast<uint8_t>(decodedDnaStr.at(5)) * 2;
 	//eyes
-	eyeColorPaletteCoordinates.x = static_cast<uint8_t>(decodedDnaStr[8]) * 2;
-	eyeColorPaletteCoordinates.y = static_cast<uint8_t>(decodedDnaStr[9]) * 2;
+	eyeColorPaletteCoordinates.x = static_cast<uint8_t>(decodedDnaStr.at(8)) * 2;
+	eyeColorPaletteCoordinates.y = static_cast<uint8_t>(decodedDnaStr.at(9)) * 2;
 
 	//accessory genes
 	const unsigned int colorGenesBytes = 12;
@@ -32,12 +32,12 @@ Imperator::CharacterPortraitData::CharacterPortraitData(const std::string& dnaSt
 		//Log(LogLevel::Debug) << "\tgene: " << geneItr.first;
 		
 		const auto geneTemplateByteIndex = colorGenesBytes + (accessoryGenesIndex + geneIndex - 3) * 4;
-		const auto characterGeneTemplateIndex = static_cast<uint8_t>(decodedDnaStr[geneTemplateByteIndex]);
+		const auto characterGeneTemplateIndex = static_cast<uint8_t>(decodedDnaStr.at(geneTemplateByteIndex));
 		const auto& [fst, snd] = gene.getGeneTemplateByIndex(characterGeneTemplateIndex);
 		//Log(LogLevel::Debug) << "\t\tgene template: " << fst;
 		
 		const auto geneTemplateObjectByteIndex = colorGenesBytes + (accessoryGenesIndex + geneIndex - 3) * 4 + 1;
-		const auto characterGeneSliderValue = static_cast<uint8_t>(decodedDnaStr[geneTemplateObjectByteIndex]) / 255;
+		const auto characterGeneSliderValue = static_cast<uint8_t>(decodedDnaStr.at(geneTemplateObjectByteIndex)) / 255;
 		auto characterGeneFoundWeightBlock = gene.getGeneTemplates().find(fst)->second.getAgeSexWeightBlocs().find(ageSexString);
 		if (characterGeneFoundWeightBlock != gene.getGeneTemplates().find(fst)->second.getAgeSexWeightBlocs().end())
 		{

--- a/ImperatorToCK3/Source/Mappers/CoaMapper/CoaMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/CoaMapper/CoaMapper.cpp
@@ -35,6 +35,6 @@ void mappers::CoaMapper::registerKeys()
 
 std::optional<std::string> mappers::CoaMapper::getCoaForFlagName(const std::string& impFlagName)
 {
-	if (coasMap.contains(impFlagName)) return coasMap[impFlagName];
+	if (coasMap.contains(impFlagName)) return coasMap.at(impFlagName);
 	return std::nullopt;
 }

--- a/ImperatorToCK3/Source/Mappers/LocalizationMapper/LocalizationMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/LocalizationMapper/LocalizationMapper.cpp
@@ -52,7 +52,7 @@ void mappers::LocalizationMapper::scrapeStream(std::istream& theStream, const st
 		std::string line;
 		getline(theStream, line);
 
-		if (line[0] == '#' || line.length() < 4)
+		if (line.at(0) == '#' || line.length() < 4)
 			continue;
 
 		const auto sepLoc = line.find_first_of(':');


### PR DESCRIPTION
Also added an `addFoundTitle` static function to be used in both Title and LandedTitles to avoid duplication.