### PR TITLE
Fixed a serious memory usage issue

### DIFF
--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -74,7 +74,7 @@
     <IntDir>$(SolutionDir)\ReleaseIntermediate\</IntDir>
     <TargetName>ImperatorToCK3Converter</TargetName>
     <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
-    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>NativeMinimumRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(ProjectDir)\..\$(Configuration)\ImperatorToCK3\</OutDir>

--- a/ImperatorToCK3/Source/Imperator/Characters/Character.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/Character.h
@@ -80,8 +80,8 @@ class Character
 	
 	std::optional<std::string> dna;
 	std::optional<CharacterPortraitData> portraitData;
-	GenesDB genes;
-	date endDate;
+	std::shared_ptr<GenesDB> genes;
+	std::shared_ptr<date> endDate;
 
 	std::pair<unsigned long long, std::shared_ptr<Family>> family;
 	std::pair<unsigned long long, std::shared_ptr<Character>> mother;

--- a/ImperatorToCK3/Source/Imperator/Characters/Character.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/Character.h
@@ -81,7 +81,6 @@ class Character
 	std::optional<std::string> dna;
 	std::optional<CharacterPortraitData> portraitData;
 	std::shared_ptr<GenesDB> genes;
-	std::shared_ptr<date> endDate;
 
 	std::pair<unsigned long long, std::shared_ptr<Family>> family;
 	std::pair<unsigned long long, std::shared_ptr<Character>> mother;

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
@@ -80,11 +80,11 @@ Imperator::Character::Factory::Factory()
 }
 
 
-std::unique_ptr<Imperator::Character> Imperator::Character::Factory::getCharacter(std::istream& theStream, const std::string& idString, GenesDB genesDB, const date& endDate)
+std::unique_ptr<Imperator::Character> Imperator::Character::Factory::getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate)
 {
 	character = std::make_unique<Character>();
 	character->ID = std::stoull(idString);
-	character->genes = std::move(genesDB);
+	character->genes = genesDB;
 	character->endDate = endDate;
 
 	parseStream(theStream);

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
@@ -80,12 +80,11 @@ Imperator::Character::Factory::Factory()
 }
 
 
-std::unique_ptr<Imperator::Character> Imperator::Character::Factory::getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate)
+std::unique_ptr<Imperator::Character> Imperator::Character::Factory::getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB)
 {
 	character = std::make_unique<Character>();
 	character->ID = std::stoull(idString);
 	character->genes = genesDB;
-	character->endDate = endDate;
 
 	parseStream(theStream);
 

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h
@@ -16,7 +16,7 @@ class Character::Factory: commonItems::parser
 {
   public:
 	explicit Factory();
-	std::unique_ptr<Character> getCharacter(std::istream& theStream, const std::string& idString, GenesDB genesDB, const date& endDate);
+	std::unique_ptr<Character> getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate);
 
   private:
 	std::unique_ptr<Character> character;

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h
@@ -16,7 +16,7 @@ class Character::Factory: commonItems::parser
 {
   public:
 	explicit Factory();
-	std::unique_ptr<Character> getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate);
+	std::unique_ptr<Character> getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB);
 
   private:
 	std::unique_ptr<Character> character;

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
@@ -7,7 +7,7 @@
 #include <set>
 
 
-Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate): genes(genesDB), endDate(endDate)
+Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB): genes(genesDB)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -17,7 +17,7 @@ Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr
 void Imperator::Characters::registerKeys()
 {
 	registerRegex("\\d+", [this](const std::string& charID, std::istream& theStream) {
-		std::shared_ptr<Character> newCharacter = characterFactory.getCharacter(theStream, charID, genes, endDate);
+		std::shared_ptr<Character> newCharacter = characterFactory.getCharacter(theStream, charID, genes);
 		characters.emplace(newCharacter->getID(), newCharacter);
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
@@ -131,7 +131,7 @@ void Imperator::Characters::linkMothersAndFathers()
 
 
 
-Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, const GenesDB& genesDB, const date& endDate): genes(std::make_shared<GenesDB>(genesDB)), endDate(std::make_shared<date>(endDate))
+Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, const GenesDB& genesDB): genes(std::make_shared<GenesDB>(genesDB))
 {
 	registerKeys();
 	parseStream(theStream);
@@ -141,7 +141,7 @@ Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, const GenesDB
 void Imperator::CharactersBloc::registerKeys()
 {
 	registerKeyword("character_database", [this](const std::string& unused, std::istream& theStream) {
-		characters = Characters(theStream, genes, endDate);
+		characters = Characters(theStream, genes);
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
@@ -7,7 +7,7 @@
 #include <set>
 
 
-Imperator::Characters::Characters(std::istream& theStream, GenesDB genesDB, const date& _endDate) : genes(std::move(genesDB)), endDate(_endDate)
+Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate): genes(genesDB), endDate(endDate)
 {
 	registerKeys();
 	parseStream(theStream);
@@ -131,7 +131,7 @@ void Imperator::Characters::linkMothersAndFathers()
 
 
 
-Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, GenesDB genesDB, const date& _endDate) : genes(std::move(genesDB)), endDate(_endDate)
+Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, const GenesDB& genesDB, const date& endDate): genes(std::make_shared<GenesDB>(genesDB)), endDate(std::make_shared<date>(endDate))
 {
 	registerKeys();
 	parseStream(theStream);

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.h
@@ -14,7 +14,7 @@ namespace Imperator
 	{
 	  public:
 		Characters() = default;
-		Characters(std::istream& theStream, GenesDB genesDB, const date& _endDate);
+		Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate);
 
 		Characters& operator= (const Characters& obj) { this->characters = obj.characters; return *this; }
 
@@ -29,8 +29,8 @@ namespace Imperator
 
 		Character::Factory characterFactory;
 
-		GenesDB genes;
-		date endDate;
+		std::shared_ptr<GenesDB> genes;
+		std::shared_ptr<date> endDate;
 
 		std::map<unsigned long long, std::shared_ptr<Character>> characters;
 	}; // class Characters
@@ -39,15 +39,15 @@ namespace Imperator
 	{
 	public:
 		CharactersBloc() = default;
-		explicit CharactersBloc(std::istream& theStream, GenesDB genesDB, const date& _endDate);
+		explicit CharactersBloc(std::istream& theStream, const GenesDB& genesDB, const date& endDate);
 
 		[[nodiscard]] const auto& getCharactersFromBloc() const { return characters; }
 
 	private:
 		void registerKeys();
 
-		GenesDB genes;
-		date endDate;
+		std::shared_ptr<GenesDB> genes;
+		std::shared_ptr<date> endDate;
 		Characters characters;
 	}; // class CharactersBloc
 } // namespace Imperator

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.h
@@ -14,7 +14,7 @@ namespace Imperator
 	{
 	  public:
 		Characters() = default;
-		Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB, const std::shared_ptr<date>& endDate);
+		Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB);
 
 		Characters& operator= (const Characters& obj) { this->characters = obj.characters; return *this; }
 
@@ -30,7 +30,7 @@ namespace Imperator
 		Character::Factory characterFactory;
 
 		std::shared_ptr<GenesDB> genes;
-		std::shared_ptr<date> endDate;
+		//std::shared_ptr<date> endDate;
 
 		std::map<unsigned long long, std::shared_ptr<Character>> characters;
 	}; // class Characters
@@ -39,7 +39,7 @@ namespace Imperator
 	{
 	public:
 		CharactersBloc() = default;
-		explicit CharactersBloc(std::istream& theStream, const GenesDB& genesDB, const date& endDate);
+		explicit CharactersBloc(std::istream& theStream, const GenesDB& genesDB);
 
 		[[nodiscard]] const auto& getCharactersFromBloc() const { return characters; }
 
@@ -47,7 +47,6 @@ namespace Imperator
 		void registerKeys();
 
 		std::shared_ptr<GenesDB> genes;
-		std::shared_ptr<date> endDate;
 		Characters characters;
 	}; // class CharactersBloc
 } // namespace Imperator

--- a/ImperatorToCK3/Source/Imperator/Characters/PortraitData.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/PortraitData.cpp
@@ -5,7 +5,7 @@
 #include <utility>
 
 
-Imperator::CharacterPortraitData::CharacterPortraitData(const std::string& dnaString, GenesDB genesDB, const std::string& ageSexString) : genes(std::move(genesDB))
+Imperator::CharacterPortraitData::CharacterPortraitData(const std::string& dnaString, const std::shared_ptr<GenesDB>& genesDB, const std::string& ageSexString) : genes(genesDB)
 {
 	const auto decodedDnaStr = base64_decode(dnaString);
 
@@ -22,10 +22,10 @@ Imperator::CharacterPortraitData::CharacterPortraitData(const std::string& dnaSt
 	//accessory genes
 	const unsigned int colorGenesBytes = 12;
 
-	auto accessoryGenes = genes.getAccessoryGenes().getGenes();
+	auto accessoryGenes = genes->getAccessoryGenes().getGenes();
 
 	//LOG(LogLevel::Debug) << "ageSex: " << ageSexString;
-	const auto accessoryGenesIndex = genes.getAccessoryGenes().getIndex();
+	const auto accessoryGenesIndex = genes->getAccessoryGenes().getIndex();
 	for (auto& [geneName, gene] : accessoryGenes)
 	{
 		const auto geneIndex = gene.getIndex();

--- a/ImperatorToCK3/Source/Imperator/Characters/PortraitData.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/PortraitData.h
@@ -27,7 +27,7 @@ class CharacterPortraitData: commonItems::parser
 {
 public:
 	CharacterPortraitData() = default;
-	explicit CharacterPortraitData(const std::string& dnaString, GenesDB genesDB, const std::string& ageSexString = "male");
+	explicit CharacterPortraitData(const std::string& dnaString, const std::shared_ptr<GenesDB>& genesDB, const std::string& ageSexString = "male");
 
 	[[nodiscard]] const auto& getHairColorPaletteCoordinates() const { return hairColorPaletteCoordinates; }
 	[[nodiscard]] const auto& getSkinColorPaletteCoordinates() const { return skinColorPaletteCoordinates; }
@@ -38,7 +38,7 @@ private:
 	CoordinatesStruct hairColorPaletteCoordinates;
 	CoordinatesStruct skinColorPaletteCoordinates;
 	CoordinatesStruct eyeColorPaletteCoordinates;
-	GenesDB genes;
+	std::shared_ptr<GenesDB> genes;
 	std::vector<AccessoryGeneStruct> accessoryGenesVector;
 };
 

--- a/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
+++ b/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
@@ -50,7 +50,7 @@ Imperator::World::World(const Configuration& theConfiguration)
 	
 	registerKeyword("character", [this](const std::string& unused, std::istream& theStream) {
 		LOG(LogLevel::Info) << "-> Loading Characters";
-		characters = CharactersBloc(theStream, genes, endDate).getCharactersFromBloc();
+		characters = CharactersBloc(theStream, genes).getCharactersFromBloc();
 		LOG(LogLevel::Info) << ">> Loaded " << characters.getCharacters().size() << " characters.";
 	});
 

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharacterTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharacterTests.cpp
@@ -8,13 +8,12 @@
 TEST(ImperatorWorld_CharacterTests, IDCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(42, theCharacter.getID());
 }
@@ -22,14 +21,13 @@ TEST(ImperatorWorld_CharacterTests, IDCanBeSet)
 TEST(ImperatorWorld_CharacterTests, cultureCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tculture=\"paradoxian\"";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("paradoxian", theCharacter.getCulture());
 }
@@ -37,13 +35,12 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeSet)
 TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.getCulture().empty());
 }
@@ -52,14 +49,13 @@ TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank)
 TEST(ImperatorWorld_CharacterTests, religionCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\treligion=\"paradoxian\"";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("paradoxian", theCharacter.getReligion());
 }
@@ -67,13 +63,12 @@ TEST(ImperatorWorld_CharacterTests, religionCanBeSet)
 TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.getReligion().empty());
 }
@@ -81,27 +76,25 @@ TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank)
 TEST(ImperatorWorld_CharacterTests, sexCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tfemale=yes";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.isFemale());
 }
 TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_FALSE(theCharacter.isFemale());
 }
@@ -109,7 +102,6 @@ TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale)
 TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	const std::vector<std::string> traitsVector{ "lustful", "submissive", "greedy" };
 
 	std::stringstream input;
@@ -118,7 +110,7 @@ TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
 	input << "\ttraits = { \"lustful\" \"submissive\" \"greedy\" }";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(traitsVector, theCharacter.getTraits());
 }
@@ -126,13 +118,12 @@ TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
 TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.getTraits().empty());
 }
@@ -140,14 +131,13 @@ TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty)
 TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tbirth_date=408.6.28"; // will be converted to AD on loading
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(date("-346.6.28"), theCharacter.getBirthDate());
 }
@@ -155,13 +145,12 @@ TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet)
 TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(date("1.1.1"), theCharacter.getBirthDate());
 }
@@ -169,14 +158,13 @@ TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1)
 TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tdeath_date=408.6.28"; // will be converted to AD on loading
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(date("-346.6.28"), theCharacter.getDeathDate());
 }
@@ -184,13 +172,12 @@ TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet)
 TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_FALSE(theCharacter.getDeathDate());
 }
@@ -198,7 +185,6 @@ TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt)
 TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -215,10 +201,10 @@ TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
 	spouse420input << "{\n";
 	spouse420input << "}";
 
-	auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 	std::map<unsigned long long, std::shared_ptr<Imperator::Character>> spousesMap;
-	spousesMap.emplace(69, Imperator::Character::Factory{}.getCharacter(spouse69input, "69", genesDB, endDate));
-	spousesMap.emplace(420, Imperator::Character::Factory{}.getCharacter(spouse420input, "420", genesDB, endDate));
+	spousesMap.emplace(69, Imperator::Character::Factory{}.getCharacter(spouse69input, "69", genesDB));
+	spousesMap.emplace(420, Imperator::Character::Factory{}.getCharacter(spouse420input, "420", genesDB));
 	theCharacter.setSpouses(spousesMap);
 
 	ASSERT_FALSE(theCharacter.getSpouses().empty());
@@ -231,13 +217,12 @@ TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
 TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.getSpouses().empty());
 }
@@ -245,14 +230,13 @@ TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty)
 TEST(ImperatorWorld_CharacterTests, childrenCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tchildren = { 69 420 } ";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_FALSE(theCharacter.getChildren().empty());
 	ASSERT_EQ(69, theCharacter.getChildren().find(69)->first);
@@ -262,13 +246,12 @@ TEST(ImperatorWorld_CharacterTests, childrenCanBeSet)
 TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.getChildren().empty());
 }
@@ -276,14 +259,13 @@ TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty)
 TEST(ImperatorWorld_CharacterTests, motherCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tmother=123";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(123, theCharacter.getMother().first);
 }
@@ -291,13 +273,12 @@ TEST(ImperatorWorld_CharacterTests, motherCanBeSet)
 TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getMother().first);
 }
@@ -305,14 +286,13 @@ TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero)
 TEST(ImperatorWorld_CharacterTests, fatherCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tfather=123";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(123, theCharacter.getFather().first);
 }
@@ -320,13 +300,12 @@ TEST(ImperatorWorld_CharacterTests, fatherCanBeSet)
 TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getFather().first);
 }
@@ -334,14 +313,13 @@ TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero)
 TEST(ImperatorWorld_CharacterTests, familyCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tfamily=123";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(123, theCharacter.getFamily().first);
 }
@@ -349,27 +327,25 @@ TEST(ImperatorWorld_CharacterTests, familyCanBeSet)
 TEST(ImperatorWorld_CharacterTests, familyDefaultsToZero)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getFamily().first);
 }
 TEST(ImperatorWorld_CharacterTests, wealthCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "wealth=\"420.5\"";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_NEAR(420.5, theCharacter.getWealth(), 0.001);
 }
@@ -377,13 +353,12 @@ TEST(ImperatorWorld_CharacterTests, wealthCanBeSet)
 TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getWealth());
 }
@@ -391,7 +366,6 @@ TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero)
 TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -400,7 +374,7 @@ TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
 	input << "}\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("Biggus Dickus", theCharacter.getName());
 }
@@ -408,13 +382,12 @@ TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
 TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_TRUE(theCharacter.getName().empty());
 }
@@ -422,13 +395,12 @@ TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank)
 TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getAttributes().martial);
 	ASSERT_EQ(0, theCharacter.getAttributes().finesse);
@@ -439,14 +411,13 @@ TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero)
 TEST(ImperatorWorld_CharacterTests, attributesCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tattributes={ martial=1 finesse=2 charisma=3 zeal=4 }";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(1, theCharacter.getAttributes().martial);
 	ASSERT_EQ(2, theCharacter.getAttributes().finesse);
@@ -457,7 +428,6 @@ TEST(ImperatorWorld_CharacterTests, attributesCanBeSet)
 TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream familyInput;
 	familyInput << "=\n";
 	familyInput << "{\n";
@@ -472,7 +442,7 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 
 	const Imperator::Family theFamily(familyInput, 42);
 
-	Imperator::Character theCharacter = *Imperator::Character::Factory{}.getCharacter(characterInput, "69", genesDB, endDate);
+	Imperator::Character theCharacter = *Imperator::Character::Factory{}.getCharacter(characterInput, "69", genesDB);
 
 	if (theCharacter.getFamily().first == theFamily.getID())
 	{
@@ -487,14 +457,13 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 TEST(ImperatorWorld_CharacterTests, dnaCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tdna=\"paradoxian\"";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("paradoxian", theCharacter.getDNA());
 }
@@ -502,13 +471,12 @@ TEST(ImperatorWorld_CharacterTests, dnaCanBeSet)
 TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_FALSE(theCharacter.getDNA());
 }
@@ -517,10 +485,9 @@ TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt)
 TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLength)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "={dna=\"AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/==\"}";
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_FALSE(theCharacter.getPortraitData());
 }
@@ -529,10 +496,9 @@ TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLeng
 TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "={dna=\"AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\"}";
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getPortraitData().value().getHairColorPaletteCoordinates().x);
 	ASSERT_EQ(0, theCharacter.getPortraitData().value().getHairColorPaletteCoordinates().y);
@@ -546,27 +512,25 @@ TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA
 TEST(ImperatorWorld_CharacterTests, ageCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tage=56\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(56, theCharacter.getAge());
 }
 TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getAge());
 }
@@ -575,7 +539,6 @@ TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0)
 TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input, input2, input3, input4;
 	input << "=\n";
 	input << "{\n";
@@ -599,10 +562,10 @@ TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
 	input4 << "\tage=8\n";
 	input4 << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
-	const auto theCharacter2 = *Imperator::Character::Factory{}.getCharacter(input2, "43", genesDB, endDate);
-	const auto theCharacter3 = *Imperator::Character::Factory{}.getCharacter(input3, "44", genesDB, endDate);
-	const auto theCharacter4 = *Imperator::Character::Factory{}.getCharacter(input4, "45", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
+	const auto theCharacter2 = *Imperator::Character::Factory{}.getCharacter(input2, "43", genesDB);
+	const auto theCharacter3 = *Imperator::Character::Factory{}.getCharacter(input3, "44", genesDB);
+	const auto theCharacter4 = *Imperator::Character::Factory{}.getCharacter(input4, "45", genesDB);
 
 	ASSERT_EQ("female", theCharacter.getAgeSex());
 	ASSERT_EQ("male", theCharacter2.getAgeSex());
@@ -613,14 +576,13 @@ TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
 TEST(ImperatorWorld_CharacterTests, provinceCanBeSet)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "\tprovince=69";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(69, theCharacter.getProvince());
 }
@@ -628,13 +590,12 @@ TEST(ImperatorWorld_CharacterTests, provinceCanBeSet)
 TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ(0, theCharacter.getProvince());
 }
@@ -642,11 +603,10 @@ TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0)
 TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "= { birth_date = 0.1.1 }";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("-754.1.1", theCharacter.getBirthDate().toString());
 }
@@ -654,11 +614,10 @@ TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC)
 TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "= { birth_date = 753.1.1 }";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("-1.1.1", theCharacter.getBirthDate().toString());
 }
@@ -666,11 +625,10 @@ TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC)
 TEST(ImperatorWorld_CharacterTests, AUC754ConvertsTo1AD)
 {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "= { birth_date = 754.1.1 }";
 
-	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
+	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB);
 
 	ASSERT_EQ("1.1.1", theCharacter.getBirthDate().toString());
 }

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharacterTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharacterTests.cpp
@@ -7,8 +7,8 @@
 
 TEST(ImperatorWorld_CharacterTests, IDCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -21,8 +21,8 @@ TEST(ImperatorWorld_CharacterTests, IDCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, cultureCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -36,8 +36,8 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -51,8 +51,8 @@ TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank)
 
 TEST(ImperatorWorld_CharacterTests, religionCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -66,8 +66,8 @@ TEST(ImperatorWorld_CharacterTests, religionCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -80,8 +80,8 @@ TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank)
 
 TEST(ImperatorWorld_CharacterTests, sexCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -94,8 +94,8 @@ TEST(ImperatorWorld_CharacterTests, sexCanBeSet)
 }
 TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -108,8 +108,8 @@ TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale)
 
 TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	const std::vector<std::string> traitsVector{ "lustful", "submissive", "greedy" };
 
 	std::stringstream input;
@@ -125,8 +125,8 @@ TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -139,8 +139,8 @@ TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty)
 
 TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -154,8 +154,8 @@ TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -168,8 +168,8 @@ TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1)
 
 TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -183,8 +183,8 @@ TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -197,8 +197,8 @@ TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt)
 
 TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -230,8 +230,8 @@ TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -244,8 +244,8 @@ TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty)
 
 TEST(ImperatorWorld_CharacterTests, childrenCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -261,8 +261,8 @@ TEST(ImperatorWorld_CharacterTests, childrenCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -275,8 +275,8 @@ TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty)
 
 TEST(ImperatorWorld_CharacterTests, motherCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -290,8 +290,8 @@ TEST(ImperatorWorld_CharacterTests, motherCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -304,8 +304,8 @@ TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero)
 
 TEST(ImperatorWorld_CharacterTests, fatherCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -319,8 +319,8 @@ TEST(ImperatorWorld_CharacterTests, fatherCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -333,8 +333,8 @@ TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero)
 
 TEST(ImperatorWorld_CharacterTests, familyCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -348,8 +348,8 @@ TEST(ImperatorWorld_CharacterTests, familyCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, familyDefaultsToZero)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -361,8 +361,8 @@ TEST(ImperatorWorld_CharacterTests, familyDefaultsToZero)
 }
 TEST(ImperatorWorld_CharacterTests, wealthCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -376,8 +376,8 @@ TEST(ImperatorWorld_CharacterTests, wealthCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -390,8 +390,8 @@ TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero)
 
 TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -407,8 +407,8 @@ TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -421,8 +421,8 @@ TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank)
 
 TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -438,8 +438,8 @@ TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero)
 
 TEST(ImperatorWorld_CharacterTests, attributesCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -456,8 +456,8 @@ TEST(ImperatorWorld_CharacterTests, attributesCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream familyInput;
 	familyInput << "=\n";
 	familyInput << "{\n";
@@ -486,8 +486,8 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 
 TEST(ImperatorWorld_CharacterTests, dnaCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -501,8 +501,8 @@ TEST(ImperatorWorld_CharacterTests, dnaCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -516,8 +516,8 @@ TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt)
 
 TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLength)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "={dna=\"AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/==\"}";
 	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
@@ -528,8 +528,8 @@ TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLeng
 
 TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "={dna=\"AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\"}";
 	const auto theCharacter = *Imperator::Character::Factory{}.getCharacter(input, "42", genesDB, endDate);
@@ -545,8 +545,8 @@ TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA
 
 TEST(ImperatorWorld_CharacterTests, ageCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -559,8 +559,8 @@ TEST(ImperatorWorld_CharacterTests, ageCanBeSet)
 }
 TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -574,8 +574,8 @@ TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0)
 
 TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input, input2, input3, input4;
 	input << "=\n";
 	input << "{\n";
@@ -612,8 +612,8 @@ TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
 
 TEST(ImperatorWorld_CharacterTests, provinceCanBeSet)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -627,8 +627,8 @@ TEST(ImperatorWorld_CharacterTests, provinceCanBeSet)
 
 TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
@@ -641,8 +641,8 @@ TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0)
 
 TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "= { birth_date = 0.1.1 }";
 
@@ -653,8 +653,8 @@ TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC)
 
 TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "= { birth_date = 753.1.1 }";
 
@@ -665,8 +665,8 @@ TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC)
 
 TEST(ImperatorWorld_CharacterTests, AUC754ConvertsTo1AD)
 {
-	const Imperator::GenesDB genesDB;
-	const date endDate;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	std::stringstream input;
 	input << "= { birth_date = 754.1.1 }";
 

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharactersTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharactersTests.cpp
@@ -7,14 +7,13 @@
 TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty)
 {
 	const auto genes = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	
 	std::stringstream input;
 	input << "=\n";
 	input << "{\n";
 	input << "}";
 
-	const Imperator::Characters characters(input, genes, endDate);
+	const Imperator::Characters characters(input, genes);
 
 	ASSERT_TRUE(characters.getCharacters().empty());
 }
@@ -22,7 +21,6 @@ TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty)
 TEST(ImperatorWorld_CharactersTests, charactersCanBeLoaded)
 {
 	const auto genes = std::make_shared<Imperator::GenesDB>();
-	const auto endDate = std::make_shared<date>();
 	
 	std::stringstream input;
 	input << "=\n";
@@ -31,7 +29,7 @@ TEST(ImperatorWorld_CharactersTests, charactersCanBeLoaded)
 	input << "43={}\n";
 	input << "}";
 
-	const Imperator::Characters characters(input, genes, endDate);
+	const Imperator::Characters characters(input, genes);
 	
 	const auto& characterItr = characters.getCharacters().find(42);
 	const auto& characterItr2 = characters.getCharacters().find(43);

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharactersTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharactersTests.cpp
@@ -6,8 +6,8 @@
 
 TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty)
 {
-	const Imperator::GenesDB genes;
-	const date endDate;
+	const auto genes = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	
 	std::stringstream input;
 	input << "=\n";
@@ -21,8 +21,8 @@ TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty)
 
 TEST(ImperatorWorld_CharactersTests, charactersCanBeLoaded)
 {
-	const Imperator::GenesDB genes;
-	const date endDate;
+	const auto genes = std::make_shared<Imperator::GenesDB>();
+	const auto endDate = std::make_shared<date>();
 	
 	std::stringstream input;
 	input << "=\n";

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/PortraitDataTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/PortraitDataTests.cpp
@@ -5,7 +5,7 @@
 
 TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToZero)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(0, testPortraitData.getHairColorPaletteCoordinates().x);
@@ -14,7 +14,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToZero)
 
 TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToMax)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "/wAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(510, testPortraitData.getHairColorPaletteCoordinates().x);
@@ -23,7 +23,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToMax)
 
 TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToArbitraryValue)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "ZAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(200, testPortraitData.getHairColorPaletteCoordinates().x);
@@ -32,7 +32,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToArbitraryValue)
 
 TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToZero)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(0, testPortraitData.getHairColorPaletteCoordinates().y);
@@ -41,7 +41,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToZero)
 
 TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToMax)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AP8AAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(510, testPortraitData.getHairColorPaletteCoordinates().y);
@@ -50,7 +50,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToMax)
 
 TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToArbitraryValue)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AGQAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(200, testPortraitData.getHairColorPaletteCoordinates().y);
@@ -59,7 +59,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToArbitraryValue)
 
 TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToZero)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(0, testPortraitData.getSkinColorPaletteCoordinates().x);
@@ -68,7 +68,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToZero)
 
 TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToMax)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAP8AAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(510, testPortraitData.getSkinColorPaletteCoordinates().x);
@@ -77,7 +77,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToMax)
 
 TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToArbitraryValue)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAGQAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(200, testPortraitData.getSkinColorPaletteCoordinates().x);
@@ -86,7 +86,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToArbitraryValue)
 
 TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToZero)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(0, testPortraitData.getSkinColorPaletteCoordinates().y);
@@ -95,7 +95,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToZero)
 
 TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToMax)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAD/AAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(510, testPortraitData.getSkinColorPaletteCoordinates().y);
@@ -104,7 +104,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToMax)
 
 TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToArbitraryValue)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAABkAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(200, testPortraitData.getSkinColorPaletteCoordinates().y);
@@ -113,7 +113,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToArbitraryValue)
 
 TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToZero)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(0, testPortraitData.getEyeColorPaletteCoordinates().x);
@@ -122,7 +122,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToZero)
 
 TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToMax)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAD/AAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(510, testPortraitData.getEyeColorPaletteCoordinates().x);
@@ -131,7 +131,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToMax)
 
 TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToArbitraryValue)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAABkAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(200, testPortraitData.getEyeColorPaletteCoordinates().x);
@@ -140,7 +140,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToArbitraryValue)
 
 TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToZero)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(0, testPortraitData.getEyeColorPaletteCoordinates().y);
@@ -149,7 +149,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToZero)
 
 TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToMax)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAA/wAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(510, testPortraitData.getEyeColorPaletteCoordinates().y);
@@ -158,7 +158,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToMax)
 
 TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToArbitraryValue)
 {
-	const Imperator::GenesDB genesDB;
+	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAZAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
 	ASSERT_EQ(200, testPortraitData.getEyeColorPaletteCoordinates().y);


### PR DESCRIPTION
`genes` and `endDate` neither need to nor should be stored in every Imperator Character. Used shared pointers instead.