### PR TITLE
Determine holdings for CK3 provinces

### DIFF
--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -125,13 +125,15 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>Source;..\imageMagick\include-windows;..\commonItems;..\cpp-base64;..\ZipLib;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_UNICODE;UNICODE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -174,7 +176,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -186,6 +188,7 @@
       <PreprocessorDefinitions>_UNICODE;UNICODE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnablePREfast>true</EnablePREfast>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -291,6 +291,7 @@
   <ItemGroup>
     <ClInclude Include="..\commonItems\Color.h" />
     <ClInclude Include="..\commonItems\CommonFunctions.h" />
+    <ClInclude Include="..\commonItems\CommonRegexes.h" />
     <ClInclude Include="..\commonItems\Date.h" />
     <ClInclude Include="..\commonItems\GameVersion.h" />
     <ClInclude Include="..\commonItems\iconvlite.h" />

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -176,7 +176,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
+      <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
@@ -346,6 +346,9 @@
     <ClInclude Include="Source\Imperator\Characters\CharacterFactory.h">
       <Filter>Imperator\Characters</Filter>
     </ClInclude>
+    <ClInclude Include="..\commonItems\CommonRegexes.h">
+      <Filter>commonItems</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\main.cpp" />

--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -44,8 +44,8 @@ CK3::World::World(const Imperator::World& impWorld, const Configuration& theConf
 
 
 	importImperatorCharacters(impWorld, theConfiguration.getConvertBirthAndDeathDates(), impWorld.getEndDate());
-	linkSpouses(impWorld);
-	linkMothersAndFathers(impWorld);
+	linkSpouses();
+	linkMothersAndFathers();
 
 
 	addHoldersAndHistoryToTitles(impWorld);
@@ -300,7 +300,7 @@ void CK3::World::removeInvalidLandlessTitles()
 	}
 }
 
-void CK3::World::linkSpouses(const Imperator::World& impWorld)
+void CK3::World::linkSpouses()
 {
 	auto counterSpouse = 0;
 	for (const auto& [ck3CharacterID, ck3Character] : characters)
@@ -322,7 +322,7 @@ void CK3::World::linkSpouses(const Imperator::World& impWorld)
 }
 
 
-void CK3::World::linkMothersAndFathers(const Imperator::World& impWorld)
+void CK3::World::linkMothersAndFathers()
 {
 	auto counterMother = 0;
 	auto counterFather = 0;

--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -253,7 +253,7 @@ void CK3::World::addHoldersAndHistoryToTitles(const Imperator::World& impWorld)
 				LOG(LogLevel::Warning) << "Capital barony province not found " << title->capitalBaronyProvince;
 			else
 			{
-				auto impProvince = provinces.find(title->capitalBaronyProvince)->second->srcProvince;
+				auto impProvince = provinces.find(title->capitalBaronyProvince)->second->imperatorProvince;
 				if (impProvince)
 				{
 					std::optional<unsigned long long> impMonarch;

--- a/ImperatorToCK3/Source/CK3/CK3World.h
+++ b/ImperatorToCK3/Source/CK3/CK3World.h
@@ -38,8 +38,8 @@ class World
 	private:
 		void importImperatorCharacters(const Imperator::World& impWorld, bool ConvertBirthAndDeathDates, date endDate);
 		void importImperatorCharacter(const std::pair<unsigned long long, std::shared_ptr<Imperator::Character>>& character, bool ConvertBirthAndDeathDates, date endDate);
-		void linkSpouses(const Imperator::World& impWorld);
-		void linkMothersAndFathers(const Imperator::World& impWorld);
+		void linkSpouses();
+		void linkMothersAndFathers();
 	
 		void importImperatorCountries(const Imperator::World& impWorld);
 		void importImperatorCountry(const std::pair<unsigned long long, std::shared_ptr<Imperator::Country>>& country);

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
@@ -108,6 +108,8 @@ void CK3::Province::setHolding()
 	case Imperator::ProvinceRank::settlement: {
 		if (imperatorProvince->isHolySite())
 			details.holding = "church_holding";
+		else if (imperatorProvince->hasFort())
+			details.holding = "castle_holding";
 		else
 			details.holding = "tribal_holding";
 		break;

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
@@ -94,18 +94,16 @@ void CK3::Province::setHolding()
 {
 	switch (imperatorProvince->getProvinceRank())
 	{
-	case Imperator::ProvinceRank::city_metropolis: {
+	case Imperator::ProvinceRank::city_metropolis:
 		details.holding = "city_holding";
 		break;
-	}
-	case Imperator::ProvinceRank::city: {
+	case Imperator::ProvinceRank::city:
 		if (imperatorProvince->hasFort())
 			details.holding = "castle_holding";
 		else
 			details.holding = "city_holding";
 		break;
-	}
-	case Imperator::ProvinceRank::settlement: {
+	case Imperator::ProvinceRank::settlement:
 		if (imperatorProvince->isHolySite())
 			details.holding = "church_holding";
 		else if (imperatorProvince->hasFort())
@@ -113,6 +111,5 @@ void CK3::Province::setHolding()
 		else
 			details.holding = "tribal_holding";
 		break;
-	}
 	}
 }

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
@@ -6,7 +6,7 @@
 //#include "../Title/Title.h"
 //#include "../../Imperator/Characters/Character.h"
 
-CK3::Province::Province(const unsigned long long id, std::istream& theStream) : provID(id), details(theStream) {} // Load from a country file, if one exists. Otherwise rely on defaults.
+CK3::Province::Province(const unsigned long long id, std::istream& theStream) : ID(id), details(theStream) {} // Load from a country file, if one exists. Otherwise rely on defaults.
 
 
 void CK3::Province::updateWith(const std::string& filePath)
@@ -19,7 +19,7 @@ void CK3::Province::initializeFromImperator(const std::shared_ptr<Imperator::Pro
                                             const mappers::CultureMapper& cultureMapper,
                                             const mappers::ReligionMapper& religionMapper)
 {
-	srcProvince = origProvince;
+	imperatorProvince = origProvince;
 	
 	// If we're initializing this from Imperator provinces, then having an owner or being a wasteland/sea is not a given -
 	// there are uncolonized provinces in Imperator, also uninhabitables have culture and religion.
@@ -32,14 +32,17 @@ void CK3::Province::initializeFromImperator(const std::shared_ptr<Imperator::Pro
 	
 	// Then culture
 	setCulture(cultureMapper);
+
+	// Holding type
+	setHolding();
 }
 
 void CK3::Province::setReligion(const mappers::ReligionMapper& religionMapper)
 {
 	auto religionSet = false;
-	if (!srcProvince->getReligion().empty())
+	if (!imperatorProvince->getReligion().empty())
 	{
-		auto religionMatch = religionMapper.match(srcProvince->getReligion(), provID, srcProvince->getID());
+		auto religionMatch = religionMapper.match(imperatorProvince->getReligion(), ID, imperatorProvince->getID());
 		if (religionMatch)
 		{
 			details.religion = *religionMatch;
@@ -64,9 +67,9 @@ void CK3::Province::setCulture(const mappers::CultureMapper& cultureMapper)
 {
 	auto cultureSet = false;
 	// do we even have a base culture?
-	if (!srcProvince->getCulture().empty())
+	if (!imperatorProvince->getCulture().empty())
 	{
-		auto cultureMatch = cultureMapper.cultureMatch(srcProvince->getCulture(), details.religion, provID, titleCountry.first);
+		auto cultureMatch = cultureMapper.cultureMatch(imperatorProvince->getCulture(), details.religion, ID, titleCountry.first);
 		if (cultureMatch)
 		{
 			details.culture = *cultureMatch;
@@ -84,5 +87,30 @@ void CK3::Province::setCulture(const mappers::CultureMapper& cultureMapper)
 	if (!cultureSet)
 	{
 		//Use default CK3 culture.
+	}
+}
+
+void CK3::Province::setHolding()
+{
+	switch (imperatorProvince->getProvinceRank())
+	{
+	case Imperator::ProvinceRank::city_metropolis: {
+		details.holding = "city_holding";
+		break;
+	}
+	case Imperator::ProvinceRank::city: {
+		if (imperatorProvince->hasFort())
+			details.holding = "castle_holding";
+		else
+			details.holding = "city_holding";
+		break;
+	}
+	case Imperator::ProvinceRank::settlement: {
+		if (imperatorProvince->isHolySite())
+			details.holding = "church_holding";
+		else
+			details.holding = "tribal_holding";
+		break;
+	}
 	}
 }

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.h
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.h
@@ -33,6 +33,7 @@ class Province
 	[[nodiscard]] const auto& getTitleCountry() const { return titleCountry; }
 	[[nodiscard]] const auto& getReligion() const { return details.religion; }
 	[[nodiscard]] const auto& getCulture() const { return details.culture; }
+	[[nodiscard]] const auto& getHolding() const { return details.holding; }
 	[[nodiscard]] auto getID() const { return ID; }
 	
 

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.h
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.h
@@ -33,21 +33,22 @@ class Province
 	[[nodiscard]] const auto& getTitleCountry() const { return titleCountry; }
 	[[nodiscard]] const auto& getReligion() const { return details.religion; }
 	[[nodiscard]] const auto& getCulture() const { return details.culture; }
-	[[nodiscard]] auto getID() const { return provID; }
+	[[nodiscard]] auto getID() const { return ID; }
 	
 
 	void registerTitleCountry(const std::pair<std::string, std::shared_ptr<Title>>& theTitle) { titleCountry = theTitle; }
 	void setReligion(const std::string& religion) { details.religion = religion; }
 
-	std::shared_ptr<Imperator::Province> srcProvince;
+	std::shared_ptr<Imperator::Province> imperatorProvince;
 
 	friend std::ostream& operator<<(std::ostream& output, const Province& province);
 
   private:
 	  void setReligion(const mappers::ReligionMapper& religionMapper);
 	  void setCulture(const mappers::CultureMapper& cultureMapper);
+	  void setHolding();
 	
-	  unsigned long long provID = 0;
+	  unsigned long long ID = 0;
 	  ProvinceDetails details;
 	  std::pair<std::string, std::shared_ptr<Title>> titleCountry;
 };

--- a/ImperatorToCK3/Source/CK3/Province/CK3ProvinceMappings.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/CK3ProvinceMappings.cpp
@@ -1,6 +1,7 @@
 #include "CK3ProvinceMappings.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 CK3::ProvinceMappings::ProvinceMappings(const std::string& theFile)
 {

--- a/ImperatorToCK3/Source/CK3/Province/CK3Provinces.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Provinces.cpp
@@ -1,6 +1,7 @@
 #include "CK3Provinces.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 CK3::Provinces::Provinces(const std::string& filePath)
 {

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 CK3::ProvinceDetails::ProvinceDetails(const std::string& filePath)
 {

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
@@ -35,13 +35,16 @@ CK3::ProvinceDetails::ProvinceDetails(std::istream& theStream)
 
 void CK3::ProvinceDetails::registerKeys()
 {
-	registerKeyword("culture", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("culture", [this](std::istream& theStream) {
 		const commonItems::singleString cultureStr(theStream);
 		culture = cultureStr.getString();
 	});
-	registerKeyword("religion", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("religion", [this](std::istream& theStream) {
 		const commonItems::singleString religionStr(theStream);
 		religion = religionStr.getString();
+	});
+	registerKeyword("holding", [this](std::istream& theStream) {
+		holding = commonItems::singleString{theStream}.getString();
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.h
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.h
@@ -1,5 +1,5 @@
-#ifndef CK3_PROVINCE_DETAILS_H
-#define CK3_PROVINCE_DETAILS_H
+#ifndef CK3_PROVINCE_DETAILS
+#define CK3_PROVINCE_DETAILS
 
 #include "Parser.h"
 
@@ -17,10 +17,11 @@ class ProvinceDetails: commonItems::parser
 	// This is a storage container for CK3::Province.
 	std::string culture;
 	std::string religion;
+	std::string holding = "none";
 
   private:
 	void registerKeys();
 };
 } // namespace CK3
 
-#endif // CK3_PROVINCE_DETAILS_H
+#endif // CK3_PROVINCE_DETAILS

--- a/ImperatorToCK3/Source/CK3/Titles/LandedTitles.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/LandedTitles.cpp
@@ -2,6 +2,7 @@
 #include "Title.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include <memory>
 
 // This is a recursive class that scrapes 00_landed_titles.txt (and related files) looking for title colors, landlessness,

--- a/ImperatorToCK3/Source/CK3/Titles/Title.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/Title.cpp
@@ -8,6 +8,7 @@
 #include "../../Mappers/GovernmentMapper/GovernmentMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 void CK3::Title::addFoundTitle(const std::shared_ptr<Title>& newTitle, std::map<std::string, std::shared_ptr<Title>>& foundTitles)

--- a/ImperatorToCK3/Source/CK3/Titles/TitlesHistory.cpp
+++ b/ImperatorToCK3/Source/CK3/Titles/TitlesHistory.cpp
@@ -1,6 +1,7 @@
 #include "TitlesHistory.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "OSCompatibilityLayer.h"
 
 CK3::TitlesHistory::TitlesHistory(const Configuration& theConfiguration)

--- a/ImperatorToCK3/Source/CK3Outputter/outProvince.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outProvince.cpp
@@ -8,6 +8,7 @@ std::ostream& CK3::operator<<(std::ostream& output, const Province& province)
 		output << "\tculture = " << province.details.culture << "\n";
 	if (!province.details.religion.empty())
 		output << "\treligion = " << province.details.religion << "\n";
+	output << "\tholding = " << province.details.holding << "\n";
 	output << "\t}\n"; // temporary workaround for replace_path in .mod not working #TODO(#33): remove when replace_path works
 	output << "}\n";
 	return output;

--- a/ImperatorToCK3/Source/CK3Outputter/outProvince.h
+++ b/ImperatorToCK3/Source/CK3Outputter/outProvince.h
@@ -1,5 +1,5 @@
-#ifndef OUT_PROVINCE_H
-#define OUT_PROVINCE_H
+#ifndef OUT_PROVINCE
+#define OUT_PROVINCE
 
 #include "../CK3/Province/CK3Province.h"
 #include <ostream>
@@ -10,4 +10,4 @@ std::ostream& operator<<(std::ostream& output, const Province& province);
 } // namespace CK3
 
 
-#endif // OUT_PROVINCE_H
+#endif // OUT_PROVINCE

--- a/ImperatorToCK3/Source/Configuration/Configuration.cpp
+++ b/ImperatorToCK3/Source/Configuration/Configuration.cpp
@@ -4,6 +4,7 @@
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 auto laFabricaDeColor = commonItems::Color::Factory{};
 

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterAttributes.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterAttributes.cpp
@@ -1,5 +1,6 @@
 #include "CharacterAttributes.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::CharacterAttributes::CharacterAttributes(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
@@ -3,6 +3,7 @@
 #include "CharacterAttributes.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterName.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterName.cpp
@@ -1,6 +1,7 @@
 #include "CharacterName.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::CharacterName::CharacterName(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
@@ -4,6 +4,7 @@
 #include "../Families/Families.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include <set>
 
 

--- a/ImperatorToCK3/Source/Imperator/Countries/Countries.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/Countries.cpp
@@ -3,6 +3,7 @@
 #include "../Families/Families.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::Countries::Countries(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Imperator/Countries/Country.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/Country.cpp
@@ -1,5 +1,6 @@
 #include "Country.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "CountryName.h"
 #include "CountryCurrencies.h"
 #include "Log.h"

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryCurrencies.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryCurrencies.cpp
@@ -1,5 +1,6 @@
 #include "CountryCurrencies.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::CountryCurrencies::CountryCurrencies(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryName.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryName.cpp
@@ -1,6 +1,7 @@
 #include "CountryName.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::CountryName::CountryName(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Imperator/Families/Families.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Families.cpp
@@ -2,6 +2,7 @@
 #include "Family.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 

--- a/ImperatorToCK3/Source/Imperator/Families/Family.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.cpp
@@ -1,6 +1,7 @@
 #include "Family.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::Family::Family(std::istream& theStream, const unsigned long long theFamilyID) : familyID(theFamilyID)
 {

--- a/ImperatorToCK3/Source/Imperator/Genes/AccessoryGene.cpp
+++ b/ImperatorToCK3/Source/Imperator/Genes/AccessoryGene.cpp
@@ -1,6 +1,7 @@
 #include "AccessoryGene.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 Imperator::AccessoryGene::AccessoryGene(std::istream& theStream)

--- a/ImperatorToCK3/Source/Imperator/Genes/AccessoryGeneTemplate.cpp
+++ b/ImperatorToCK3/Source/Imperator/Genes/AccessoryGeneTemplate.cpp
@@ -1,6 +1,7 @@
 #include "AccessoryGeneTemplate.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "WeightBlock.h"
 
 

--- a/ImperatorToCK3/Source/Imperator/Genes/AccessoryGenes.cpp
+++ b/ImperatorToCK3/Source/Imperator/Genes/AccessoryGenes.cpp
@@ -1,6 +1,7 @@
 #include "AccessoryGenes.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 Imperator::AccessoryGenes::AccessoryGenes(std::istream& theStream)

--- a/ImperatorToCK3/Source/Imperator/Genes/GenesDB.cpp
+++ b/ImperatorToCK3/Source/Imperator/Genes/GenesDB.cpp
@@ -1,6 +1,7 @@
 #include "GenesDB.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 Imperator::GenesDB::GenesDB(const std::string& thePath)

--- a/ImperatorToCK3/Source/Imperator/Genes/WeightBlock.cpp
+++ b/ImperatorToCK3/Source/Imperator/Genes/WeightBlock.cpp
@@ -1,6 +1,7 @@
 #include "WeightBlock.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 Imperator::WeightBlock::WeightBlock(std::istream& theStream)

--- a/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
+++ b/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
@@ -6,6 +6,7 @@
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include <ZipFile.h>
 #include <filesystem>
 #include <fstream>

--- a/ImperatorToCK3/Source/Imperator/Provinces/PopFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/PopFactory.cpp
@@ -1,6 +1,7 @@
 #include "PopFactory.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 

--- a/ImperatorToCK3/Source/Imperator/Provinces/Pops.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Pops.cpp
@@ -3,6 +3,7 @@
 #include "PopFactory.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
 void Imperator::Pops::loadPops(std::istream& theStream)

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
@@ -1,4 +1,4 @@
-#include "Province.h"
+﻿#include "Province.h"
 #include "Pop.h"
 #include "Log.h"
 #include "ParserHelpers.h"
@@ -42,6 +42,12 @@ void Imperator::Province::registerKeys()
 			provinceRank = ProvinceRank::city_metropolis;
 		else
 			Log(LogLevel::Warning) << "Unknown province rank for province " << provinceID << ": " << provinceRankStr;
+	});
+	registerKeyword("fort", [this](const std::string& unused, std::istream& theStream) {
+		fort = commonItems::singleString{ theStream }.getString() == "yes";
+	});
+	registerKeyword("holy_site", [this](const std::string& unused, std::istream& theStream) {
+		holySite = commonItems::singleULlong{ theStream }.getULlong() != 4294967295; // 4294967295 is 2^32 − 1 and is the default value
 	});
 	registerKeyword("buildings", [this](const std::string& unused, std::istream& theStream) {
 		const auto buildingsVector = commonItems::intList{ theStream }.getInts();

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
@@ -15,30 +15,36 @@ Imperator::Province::Province(std::istream& theStream, const unsigned long long 
 void Imperator::Province::registerKeys()
 {
 	registerKeyword("province_name", [this](const std::string& unused, std::istream& theStream) {
-		name = ProvinceName(theStream).getName();
+		name = ProvinceName{ theStream }.getName();
 	});
 	registerKeyword("culture", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleString cultureStr(theStream);
-		culture = cultureStr.getString();
+		culture = commonItems::singleString{ theStream }.getString();
 	});
 	registerKeyword("religion", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleString religionStr(theStream);
-		religion = religionStr.getString();
+		religion = commonItems::singleString{ theStream }.getString();
 	});
 	registerKeyword("owner", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleULlong ownerULlong(theStream);
-		owner = ownerULlong.getULlong();
+		owner = commonItems::singleULlong{ theStream }.getULlong();
 	});
 	registerKeyword("controller", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleULlong controllerULlong(theStream);
-		controller = controllerULlong.getULlong();
+		controller = commonItems::singleULlong{ theStream }.getULlong();
 	});
 	registerKeyword("pop", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleULlong popLongLong(theStream);
-		pops.insert(std::pair(popLongLong.getULlong(), nullptr));
+		pops.emplace(commonItems::singleULlong{ theStream }.getULlong(), nullptr);
+	});
+	registerKeyword("province_rank", [this](const std::string& unused, std::istream& theStream) {
+		const auto provinceRankStr = commonItems::singleString{ theStream }.getString();
+		if (provinceRankStr == "settlement")
+			provinceRank = ProvinceRank::settlement;
+		else if (provinceRankStr == "city")
+			provinceRank = ProvinceRank::city;
+		else if (provinceRankStr == "city_metropolis")
+			provinceRank = ProvinceRank::city_metropolis;
+		else
+			Log(LogLevel::Warning) << "Unknown province rank for province " << provinceID << ": " << provinceRankStr;
 	});
 	registerKeyword("buildings", [this](const std::string& unused, std::istream& theStream) {
-		const auto buildingsVector = commonItems::intList(theStream).getInts();
+		const auto buildingsVector = commonItems::intList{ theStream }.getInts();
 		buildingsCount = std::accumulate(buildingsVector.begin(), buildingsVector.end(), 0);
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
@@ -2,6 +2,7 @@
 #include "Pop.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "ProvinceName.h"
 #include <numeric>
 

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
@@ -33,8 +33,8 @@ void Imperator::Province::registerKeys()
 	registerKeyword("pop", [this](const std::string& unused, std::istream& theStream) {
 		pops.emplace(commonItems::singleULlong{ theStream }.getULlong(), nullptr);
 	});
-	registerKeyword("province_rank", [this](const std::string& unused, std::istream& theStream) {
-		const auto provinceRankStr = commonItems::singleString{ theStream }.getString();
+	registerKeyword("province_rank", [this](std::istream& theStream) {
+		const auto provinceRankStr = commonItems::getString(theStream);
 		if (provinceRankStr == "settlement")
 			provinceRank = ProvinceRank::settlement;
 		else if (provinceRankStr == "city")
@@ -44,11 +44,11 @@ void Imperator::Province::registerKeys()
 		else
 			Log(LogLevel::Warning) << "Unknown province rank for province " << provinceID << ": " << provinceRankStr;
 	});
-	registerKeyword("fort", [this](const std::string& unused, std::istream& theStream) {
-		fort = commonItems::singleString{ theStream }.getString() == "yes";
+	registerKeyword("fort", [this](std::istream& theStream) {
+		fort = commonItems::getString(theStream) == "yes";
 	});
-	registerKeyword("holy_site", [this](const std::string& unused, std::istream& theStream) {
-		holySite = commonItems::singleULlong{ theStream }.getULlong() != 4294967295; // 4294967295 is 2^32 − 1 and is the default value
+	registerKeyword("holy_site", [this](std::istream& theStream) {
+		holySite = commonItems::getULlong(theStream) != 4294967295; // 4294967295 is 2^32 − 1 and is the default value
 	});
 	registerKeyword("buildings", [this](const std::string& unused, std::istream& theStream) {
 		const auto buildingsVector = commonItems::intList{ theStream }.getInts();

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.h
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.h
@@ -4,6 +4,8 @@
 
 namespace Imperator
 {
+	enum class ProvinceRank { settlement, city, city_metropolis };
+
 	class Pop;
 	class Country;
 	class Province: commonItems::parser
@@ -36,6 +38,7 @@ namespace Imperator
 		std::string religion;
 		unsigned long long owner = 0;
 		unsigned long long controller = 0;
+		ProvinceRank provinceRank;
 		unsigned int buildingsCount = 0;
 		std::map<unsigned long long, std::shared_ptr<Pop>> pops;
 	};

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.h
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.h
@@ -21,8 +21,11 @@ namespace Imperator
 		[[nodiscard]] const auto& getOwner() const { return owner; }
 		[[nodiscard]] const auto& getController() const { return controller; }
 		[[nodiscard]] const auto& getPops() const { return pops; }
-		[[nodiscard]] auto getBuildingsCount() const { return buildingsCount; }
+		[[nodiscard]] const auto& getProvinceRank() const {	return provinceRank; }
+		[[nodiscard]] const auto& hasFort() const { return fort; }
+		[[nodiscard]] const auto& isHolySite() const { return holySite; }
 
+		[[nodiscard]] auto getBuildingsCount() const { return buildingsCount; }
 		[[nodiscard]] auto getPopCount() const { return static_cast<int>(pops.size()); }
 
 		void setPops(const std::map<unsigned long long, std::shared_ptr<Pop>>& newPops) { pops = newPops; }
@@ -39,6 +42,8 @@ namespace Imperator
 		unsigned long long owner = 0;
 		unsigned long long controller = 0;
 		ProvinceRank provinceRank;
+		bool fort = false;
+		bool holySite = false;
 		unsigned int buildingsCount = 0;
 		std::map<unsigned long long, std::shared_ptr<Pop>> pops;
 	};

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.h
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.h
@@ -41,7 +41,7 @@ namespace Imperator
 		std::string religion;
 		unsigned long long owner = 0;
 		unsigned long long controller = 0;
-		ProvinceRank provinceRank;
+		ProvinceRank provinceRank = ProvinceRank::settlement;
 		bool fort = false;
 		bool holySite = false;
 		unsigned int buildingsCount = 0;

--- a/ImperatorToCK3/Source/Imperator/Provinces/ProvinceName.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/ProvinceName.cpp
@@ -1,6 +1,7 @@
 #include "ProvinceName.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::ProvinceName::ProvinceName(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Imperator/Provinces/Provinces.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Provinces.cpp
@@ -5,6 +5,7 @@
 #include "../Countries/Country.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 Imperator::Provinces::Provinces(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/CoaMapper/CoaMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/CoaMapper/CoaMapper.cpp
@@ -1,6 +1,7 @@
 #include "CoaMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "OSCompatibilityLayer.h"
 
 mappers::CoaMapper::CoaMapper(const Configuration& theConfiguration)

--- a/ImperatorToCK3/Source/Mappers/CultureMapper/CultureMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/CultureMapper/CultureMapper.cpp
@@ -1,6 +1,7 @@
 #include "CultureMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::CultureMapper::CultureMapper(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/CultureMapper/CultureMappingRule.cpp
+++ b/ImperatorToCK3/Source/Mappers/CultureMapper/CultureMappingRule.cpp
@@ -1,6 +1,7 @@
 #include "CultureMappingRule.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::CultureMappingRule::CultureMappingRule(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/GovernmentMapper/GovernmentMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/GovernmentMapper/GovernmentMapper.cpp
@@ -1,6 +1,7 @@
 #include "GovernmentMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "GovernmentMapping.h"
 
 mappers::GovernmentMapper::GovernmentMapper()

--- a/ImperatorToCK3/Source/Mappers/GovernmentMapper/GovernmentMapping.cpp
+++ b/ImperatorToCK3/Source/Mappers/GovernmentMapper/GovernmentMapping.cpp
@@ -1,5 +1,6 @@
 #include "GovernmentMapping.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::GovernmentMapping::GovernmentMapping(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/NicknameMapper/NicknameMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/NicknameMapper/NicknameMapper.cpp
@@ -1,6 +1,7 @@
 #include "NicknameMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "NicknameMapping.h"
 
 mappers::NicknameMapper::NicknameMapper()

--- a/ImperatorToCK3/Source/Mappers/NicknameMapper/NicknameMapping.cpp
+++ b/ImperatorToCK3/Source/Mappers/NicknameMapper/NicknameMapping.cpp
@@ -1,5 +1,6 @@
 #include "NicknameMapping.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::NicknameMapping::NicknameMapping(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/ProvinceMapper/ProvinceMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/ProvinceMapper/ProvinceMapper.cpp
@@ -3,6 +3,7 @@
 #include "../../Configuration/Configuration.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "ProvinceMapping.h"
 #include <filesystem>
 #include <fstream>

--- a/ImperatorToCK3/Source/Mappers/ProvinceMapper/ProvinceMapping.cpp
+++ b/ImperatorToCK3/Source/Mappers/ProvinceMapper/ProvinceMapping.cpp
@@ -1,5 +1,6 @@
 #include "ProvinceMapping.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::ProvinceMapping::ProvinceMapping(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/ProvinceMapper/ProvinceMappingsVersion.cpp
+++ b/ImperatorToCK3/Source/Mappers/ProvinceMapper/ProvinceMappingsVersion.cpp
@@ -1,5 +1,6 @@
 #include "ProvinceMappingsVersion.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::ProvinceMappingsVersion::ProvinceMappingsVersion(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/RegionMapper/CK3Region.cpp
+++ b/ImperatorToCK3/Source/Mappers/RegionMapper/CK3Region.cpp
@@ -1,5 +1,6 @@
 #include "CK3Region.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "Log.h"
 
 mappers::CK3Region::CK3Region(std::istream& theStream)

--- a/ImperatorToCK3/Source/Mappers/RegionMapper/CK3RegionMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/RegionMapper/CK3RegionMapper.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 namespace fs = std::filesystem;
 

--- a/ImperatorToCK3/Source/Mappers/RegionMapper/ImperatorArea.cpp
+++ b/ImperatorToCK3/Source/Mappers/RegionMapper/ImperatorArea.cpp
@@ -1,5 +1,6 @@
 #include "ImperatorArea.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "Log.h"
 
 mappers::ImperatorArea::ImperatorArea(std::istream& theStream)

--- a/ImperatorToCK3/Source/Mappers/RegionMapper/ImperatorRegion.cpp
+++ b/ImperatorToCK3/Source/Mappers/RegionMapper/ImperatorRegion.cpp
@@ -1,5 +1,6 @@
 #include "ImperatorRegion.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "Log.h"
 
 mappers::ImperatorRegion::ImperatorRegion(std::istream& theStream)

--- a/ImperatorToCK3/Source/Mappers/RegionMapper/ImperatorRegionMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/RegionMapper/ImperatorRegionMapper.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 namespace fs = std::filesystem;
 

--- a/ImperatorToCK3/Source/Mappers/ReligionMapper/ReligionMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/ReligionMapper/ReligionMapper.cpp
@@ -1,6 +1,7 @@
 #include "ReligionMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::ReligionMapper::ReligionMapper()
 {

--- a/ImperatorToCK3/Source/Mappers/ReligionMapper/ReligionMapping.cpp
+++ b/ImperatorToCK3/Source/Mappers/ReligionMapper/ReligionMapping.cpp
@@ -1,5 +1,6 @@
 #include "ReligionMapping.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "Log.h"
 #include "Mappers/RegionMapper/ImperatorRegionMapper.h"
 #include "Mappers/RegionMapper/CK3RegionMapper.h"

--- a/ImperatorToCK3/Source/Mappers/TagTitleMapper/TagTitleMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/TagTitleMapper/TagTitleMapper.cpp
@@ -1,6 +1,7 @@
 #include "TagTitleMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "Imperator/Countries/Country.h"
 
 

--- a/ImperatorToCK3/Source/Mappers/TagTitleMapper/TagTitleMapping.cpp
+++ b/ImperatorToCK3/Source/Mappers/TagTitleMapper/TagTitleMapping.cpp
@@ -1,5 +1,6 @@
 #include "TagTitleMapping.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::TagTitleMapping::TagTitleMapping(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/TraitMapper/TraitMapper.cpp
+++ b/ImperatorToCK3/Source/Mappers/TraitMapper/TraitMapper.cpp
@@ -1,6 +1,7 @@
 #include "TraitMapper.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 #include "TraitMapping.h"
 
 mappers::TraitMapper::TraitMapper()

--- a/ImperatorToCK3/Source/Mappers/TraitMapper/TraitMapping.cpp
+++ b/ImperatorToCK3/Source/Mappers/TraitMapper/TraitMapping.cpp
@@ -1,5 +1,6 @@
 #include "TraitMapping.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::TraitMapping::TraitMapping(std::istream& theStream)
 {

--- a/ImperatorToCK3/Source/Mappers/VersionParser/VersionParser.cpp
+++ b/ImperatorToCK3/Source/Mappers/VersionParser/VersionParser.cpp
@@ -1,5 +1,6 @@
 #include "VersionParser.h"
 #include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 mappers::VersionParser::VersionParser()
 {

--- a/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvinceTests.cpp
+++ b/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvinceTests.cpp
@@ -1,5 +1,8 @@
 #include "gtest/gtest.h"
 #include "../ImperatorToCK3/Source/CK3/Province/CK3Province.h"
+#include "../ImperatorToCK3/Source/Imperator/Provinces/Province.h"
+#include "Mappers/CultureMapper/CultureMapper.h"
+#include "Mappers/ReligionMapper/ReligionMapper.h"
 #include <sstream>
 
 
@@ -44,4 +47,54 @@ TEST(CK3World_CK3ProvinceTests, provinceCanBeUpdatedFromFile)
 	province.updateWith("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsCorrect.txt");
 	ASSERT_EQ("orthodox", province.getReligion());
 	ASSERT_EQ("roman", province.getCulture());
+}
+
+TEST(CK3World_CK3ProvinceTests, holdingDefaultsToNone)
+{
+	const CK3::Province province;
+
+	ASSERT_EQ("none", province.getHolding());
+}
+TEST(CK3World_CK3ProvinceTests, holdingCanBeSet)
+{
+	std::stringstream input{ "= { holding = castle_holding }" };
+	CK3::Province province{42, input};
+	ASSERT_EQ("castle_holding", province.getHolding());
+}
+
+
+TEST(ImperatorWorld_ProvinceTests, setHoldingLogicWorks)
+{
+	std::stringstream input{ " = { province_rank=city_metropolis }" };
+	std::stringstream input2{ " = { province_rank=city fort=yes }" };
+	std::stringstream input3{ " = { province_rank=city }" };
+	std::stringstream input4{ " = { province_rank=settlement holy_site = 69 fort=yes }" };
+	std::stringstream input5{ " = { province_rank=settlement fort=yes }" };
+	std::stringstream input6{ " = { province_rank=settlement }" };
+
+	auto impProvince = std::make_shared<Imperator::Province>(input, 42);
+	auto impProvince2 = std::make_shared<Imperator::Province>(input2, 43);
+	auto impProvince3 = std::make_shared<Imperator::Province>(input3, 44);
+	auto impProvince4 = std::make_shared<Imperator::Province>(input4, 45);
+	auto impProvince5 = std::make_shared<Imperator::Province>(input5, 46);
+	auto impProvince6 = std::make_shared<Imperator::Province>(input6, 47);
+
+	CK3::Province province, province2, province3, province4, province5, province6;
+
+	mappers::CultureMapper cultureMapper{};
+	mappers::ReligionMapper religionMapper{};
+
+	province.initializeFromImperator(impProvince, cultureMapper, religionMapper);
+	province2.initializeFromImperator(impProvince2, cultureMapper, religionMapper);
+	province3.initializeFromImperator(impProvince3, cultureMapper, religionMapper);
+	province4.initializeFromImperator(impProvince4, cultureMapper, religionMapper);
+	province5.initializeFromImperator(impProvince5, cultureMapper, religionMapper);
+	province6.initializeFromImperator(impProvince6, cultureMapper, religionMapper);
+
+	ASSERT_EQ("city_holding", province.getHolding());
+	ASSERT_EQ("castle_holding", province2.getHolding());
+	ASSERT_EQ("city_holding", province3.getHolding());
+	ASSERT_EQ("church_holding", province4.getHolding());
+	ASSERT_EQ("castle_holding", province5.getHolding());
+	ASSERT_EQ("tribal_holding", province6.getHolding());
 }

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Provinces/ProvinceTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Provinces/ProvinceTests.cpp
@@ -146,6 +146,64 @@ TEST(ImperatorWorld_ProvinceTests, popsCanBeSet)
 	ASSERT_EQ(4, theProvince.getPopCount());
 }
 
+TEST(ImperatorWorld_ProvinceTests, province_rankDefaultsToSettlement)
+{
+	std::stringstream input;
+	const Imperator::Province province(input, 42);
+
+	ASSERT_EQ(Imperator::ProvinceRank::settlement, province.getProvinceRank());
+}
+
+TEST(ImperatorWorld_ProvinceTests, province_rankCanBeSet)
+{
+	std::stringstream input{ "= { province_rank=settelement }" };
+	std::stringstream input2{ "= { province_rank=city }" };
+	std::stringstream input3{ "= { province_rank=city_metropolis }" };
+
+	const Imperator::Province province(input, 42);
+	const Imperator::Province province2(input2, 43);
+	const Imperator::Province province3(input3, 44);
+
+	ASSERT_EQ(Imperator::ProvinceRank::settlement, province.getProvinceRank());
+	ASSERT_EQ(Imperator::ProvinceRank::city, province2.getProvinceRank());
+	ASSERT_EQ(Imperator::ProvinceRank::city_metropolis, province3.getProvinceRank());
+}
+
+TEST(ImperatorWorld_ProvinceTests, fortDefaultsToFalse)
+{
+	std::stringstream input;
+	const Imperator::Province province(input, 42);
+
+	ASSERT_FALSE(province.hasFort());
+}
+
+TEST(ImperatorWorld_ProvinceTests, fortCanBeSet)
+{
+	std::stringstream input{" = { fort=yes }"};
+	const Imperator::Province province(input, 42);
+
+	ASSERT_TRUE(province.hasFort());
+}
+
+TEST(ImperatorWorld_ProvinceTests, holySiteDefaultsToFalse)
+{
+	std::stringstream input;
+	const Imperator::Province province(input, 42);
+
+	ASSERT_FALSE(province.isHolySite());
+}
+
+TEST(ImperatorWorld_ProvinceTests, holySiteCanBeSet)
+{
+	std::stringstream input{ " = { holy_site=4294967295 }" }; // this value means no holy site
+	std::stringstream input2{ " = { holy_site=56 }" };
+	const Imperator::Province province(input, 42);
+	const Imperator::Province province2(input2, 43);
+
+	ASSERT_FALSE(province.isHolySite());
+	ASSERT_TRUE(province2.isHolySite());
+}
+
 TEST(ImperatorWorld_ProvinceTests, buildingsCountCanBeSet)
 {
 	std::stringstream input;


### PR DESCRIPTION
The logic:
```
void CK3::Province::setHolding()
{
	switch (imperatorProvince->getProvinceRank())
	{
	case Imperator::ProvinceRank::city_metropolis: {
		details.holding = "city_holding";
		break;
	}
	case Imperator::ProvinceRank::city: {
		if (imperatorProvince->hasFort())
			details.holding = "castle_holding";
		else
			details.holding = "city_holding";
		break;
	}
	case Imperator::ProvinceRank::settlement: {
		if (imperatorProvince->isHolySite())
			details.holding = "church_holding";
		else if (imperatorProvince->hasFort())
			details.holding = "castle_holding";
		else
			details.holding = "tribal_holding";
		break;
	}
	}
}
```

+ also updated commonItems
