### PR TITLE
Used History to parse CK3 province details

### DIFF
--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.cpp
@@ -6,14 +6,9 @@
 //#include "Title/Title.h"
 //#include "Imperator/Characters/Character.h"
 
+
+
 CK3::Province::Province(const unsigned long long id, std::istream& theStream) : ID(id), details(theStream) {} // Load from a country file, if one exists. Otherwise rely on defaults.
-
-
-void CK3::Province::updateWith(const std::string& filePath)
-{
-	// We're doing this for special reason and from a specific source.
-	details.updateWith(filePath);
-}
 
 void CK3::Province::initializeFromImperator(const std::shared_ptr<Imperator::Province>& origProvince,
                                             const mappers::CultureMapper& cultureMapper,

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.h
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.h
@@ -1,9 +1,13 @@
 #ifndef CK3_PROVINCE_H
 #define CK3_PROVINCE_H
 
+
+
 #include "ProvinceDetails.h"
 #include <memory>
 #include <string>
+
+
 
 namespace Imperator
 {
@@ -15,6 +19,7 @@ class CultureMapper;
 class ReligionMapper;
 } // namespace mappers
 
+
 namespace CK3
 {
 class Title;
@@ -25,7 +30,6 @@ class Province
 
 	Province(unsigned long long id, std::istream& theStream);
 
-	void updateWith(const std::string& filePath);
 	void initializeFromImperator(const std::shared_ptr<Imperator::Province>& origProvince,
 	                             const mappers::CultureMapper& cultureMapper,
 	                             const mappers::ReligionMapper& religionMapper);

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
@@ -1,42 +1,29 @@
 #include "ProvinceDetails.h"
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
-#include "ParserHelpers.h"
 #include "CommonRegexes.h"
 
-CK3::ProvinceDetails::ProvinceDetails(const std::string& filePath)
-{
-	registerKeys();
-	if (commonItems::DoesFileExist(filePath))
-	{
-		parseFile(filePath);
-	}
-	else Log(LogLevel::Error) << "Could not open " << filePath << " to load province details.";
-	clearRegisteredKeywords();
-}
 
-void CK3::ProvinceDetails::updateWith(const std::string& filePath)
-{
-	registerKeys();
-	if (commonItems::DoesFileExist(filePath))
-	{
-		parseFile(filePath);
-	}
-	else Log(LogLevel::Error) << "Could not open " << filePath << " to update province details.";
-	clearRegisteredKeywords();
-}
+
+History::Factory CK3::ProvinceDetails::historyFactory = History::Factory({
+	{"culture", "culture", std::nullopt},
+	{"religion", "religion", std::nullopt},
+	{"holding", "holding", "none"}
+});
 
 CK3::ProvinceDetails::ProvinceDetails(std::istream& theStream)
 {
-	registerKeys();
-	parseStream(theStream);
-	clearRegisteredKeywords();
-}
-
-void CK3::ProvinceDetails::registerKeys()
-{
-	registerSetter("culture", culture);
-	registerSetter("religion", religion);
-	registerSetter("holding", holding);
-	registerMatcher(commonItems::catchallRegexMatch, commonItems::ignoreItem);
+	const auto history = historyFactory.getHistory(theStream);
+	const auto cultureOpt = history->getFieldValue("culture", date(867, 1, 1));
+	const auto religionOpt = history->getFieldValue("religion", date(867, 1, 1));
+	const auto holdingOpt = history->getFieldValue("holding", date(867, 1, 1));
+	if (cultureOpt) {
+		culture = *cultureOpt;
+	}
+	if (religionOpt) {
+		religion = *religionOpt;
+	}
+	if (holdingOpt) {
+		holding = *holdingOpt;
+	}
 }

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
@@ -14,9 +14,10 @@ History::Factory CK3::ProvinceDetails::historyFactory = History::Factory({
 CK3::ProvinceDetails::ProvinceDetails(std::istream& theStream)
 {
 	const auto history = historyFactory.getHistory(theStream);
-	const auto cultureOpt = history->getFieldValue("culture", date(867, 1, 1));
-	const auto religionOpt = history->getFieldValue("religion", date(867, 1, 1));
-	const auto holdingOpt = history->getFieldValue("holding", date(867, 1, 1));
+	const date date{867, 1, 1};
+	const auto cultureOpt = history->getFieldValue("culture", date);
+	const auto religionOpt = history->getFieldValue("religion", date);
+	const auto holdingOpt = history->getFieldValue("holding", date);
 	if (cultureOpt) {
 		culture = *cultureOpt;
 	}

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
@@ -6,9 +6,9 @@
 
 
 History::Factory CK3::ProvinceDetails::historyFactory = History::Factory({
-	{"culture", "culture", std::nullopt},
-	{"religion", "religion", std::nullopt},
-	{"holding", "holding", "none"}
+	{.fieldName="culture", .setter="culture", .initialValue=std::nullopt},
+	{.fieldName="religion", .setter="religion", .initialValue=std::nullopt},
+	{.fieldName="holding", .setter="holding", .initialValue="none"}
 });
 
 CK3::ProvinceDetails::ProvinceDetails(std::istream& theStream)

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.h
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.h
@@ -1,7 +1,12 @@
-#ifndef CK3_PROVINCE_DETAILS
-#define CK3_PROVINCE_DETAILS
+#ifndef CK3_PROVINCE_DETAILS_H
+#define CK3_PROVINCE_DETAILS_H
+
+
 
 #include "ConvenientParser.h"
+#include "CommonUtilities/HistoryFactory.h"
+
+
 
 namespace CK3
 {
@@ -9,9 +14,7 @@ class ProvinceDetails: commonItems::convenientParser
 {
   public:
 	ProvinceDetails() = default;
-	explicit ProvinceDetails(const std::string& filePath);
 	explicit ProvinceDetails(std::istream& theStream);
-	void updateWith(const std::string& filePath);
 
 	// These values are open to ease management.
 	// This is a storage container for CK3::Province.
@@ -20,8 +23,8 @@ class ProvinceDetails: commonItems::convenientParser
 	std::string holding = "none";
 
   private:
-	void registerKeys();
+	static History::Factory historyFactory;
 };
 } // namespace CK3
 
-#endif // CK3_PROVINCE_DETAILS
+#endif // CK3_PROVINCE_DETAILS_H

--- a/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvinceDetailsTests.cpp
+++ b/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvinceDetailsTests.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
-#include "../ImperatorToCK3/Source/CK3/Province/ProvinceDetails.h"
+#include "CK3/Province/ProvinceDetails.h"
 #include <sstream>
+
 
 
 TEST(CK3World_CK3ProvinceDetailsTests, cultureDefaultsToEmpty)
@@ -17,12 +18,11 @@ TEST(CK3World_CK3ProvinceDetailsTests, religionDefaultsToEmpty)
 	ASSERT_EQ("", details.religion);
 }
 
-TEST(CK3World_CK3ProvinceDetailsTests, detailsCanBeLoadedFromPath)
+TEST(CK3World_CK3ProvinceDetailsTests, holdingDefaultsToNone)
 {
-	const CK3::ProvinceDetails details("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsCorrect.txt");
+	const CK3::ProvinceDetails details;
 
-	ASSERT_EQ("roman", details.culture);
-	ASSERT_EQ("orthodox", details.religion);
+	ASSERT_EQ("none", details.holding);
 }
 
 TEST(CK3World_CK3ProvinceDetailsTests, detailsCanBeLoadedFromStream)
@@ -36,58 +36,18 @@ TEST(CK3World_CK3ProvinceDetailsTests, detailsCanBeLoadedFromStream)
 	ASSERT_EQ("orthodox", details.religion);
 }
 
-TEST(CK3World_CK3ProvinceDetailsTests, detailsCanBeUpdatedFromPath)
+TEST(CK3World_CK3ProvinceDetailsTests, detailsAreLoadedFromDatedBlocks)
 {
-	CK3::ProvinceDetails details;
-	details.culture = "culture";
-	details.religion = "religion";
+	std::stringstream input;
+	input << "= {"
+	"religion = catholic\n"
+	"random_param = random_stuff\n"
+	"culture = roman\n"
+	"850.1.1 = { religion=orthodox holding=castle_holding }"
+	"}";
 
-	ASSERT_EQ("culture", details.culture);
-	ASSERT_EQ("religion", details.religion);
-	details.updateWith("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsCorrect.txt");
-	ASSERT_EQ("roman", details.culture);
+	const CK3::ProvinceDetails details(input);
+
+	ASSERT_EQ("castle_holding", details.holding);
 	ASSERT_EQ("orthodox", details.religion);
 }
-
-TEST(CK3World_CK3ProvinceDetailsTests, detailsLoadedFromBlankFileAreBlank)
-{
-	const CK3::ProvinceDetails details("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsBlank.txt");
-	ASSERT_EQ("", details.culture);
-	ASSERT_EQ("", details.religion);
-}
-
-TEST(CK3World_CK3ProvinceDetailsTests, updateWithWrongFilePathResultsInLogError)
-{
-	CK3::ProvinceDetails details;
-
-	std::stringstream log;
-	auto* stdOutBuf = std::cout.rdbuf();
-	std::cout.rdbuf(log.rdbuf());
-
-	details.updateWith("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsMissing.txt");
-
-	std::cout.rdbuf(stdOutBuf);
-	auto stringLog = log.str();
-	const auto newLine = stringLog.find_first_of('\n');
-	stringLog = stringLog.substr(0, newLine);
-	
-
-	ASSERT_EQ("   [ERROR] Could not open TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsMissing.txt to update province details.", stringLog);
-}
-
-TEST(CK3World_CK3ProvinceDetailsTests, provinceDetailsWithWrongFilePathResultsInLogError)
-{
-	std::stringstream log;
-	auto* stdOutBuf = std::cout.rdbuf();
-	std::cout.rdbuf(log.rdbuf());
-
-	const CK3::ProvinceDetails details("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsMissing.txt");
-
-	std::cout.rdbuf(stdOutBuf);
-	auto stringLog = log.str();
-	const auto newLine = stringLog.find_first_of('\n');
-	stringLog = stringLog.substr(0, newLine);
-
-	ASSERT_EQ("   [ERROR] Could not open TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsMissing.txt to load province details.", stringLog);
-}
-

--- a/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvinceTests.cpp
+++ b/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvinceTests.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 
 
+
 TEST(CK3World_CK3ProvinceTests, idDefaultsTo0)
 {
 	const CK3::Province province;
@@ -36,15 +37,6 @@ TEST(CK3World_CK3ProvinceTests, provinceCanBeLoadedFromStream)
 	input << "{ culture=roman random_key=random_value religion=orthodox }";
 	CK3::Province province(42, input);
 	ASSERT_EQ(42, province.getID());
-	ASSERT_EQ("orthodox", province.getReligion());
-	ASSERT_EQ("roman", province.getCulture());
-}
-TEST(CK3World_CK3ProvinceTests, provinceCanBeUpdatedFromFile)
-{
-	std::stringstream input;
-	input << "{ culture=dfgdfgdfg random_key=random_value religion=ertert }";
-	CK3::Province province(42, input);
-	province.updateWith("TestFiles/CK3ProvinceDetails/CK3ProvinceDetailsCorrect.txt");
 	ASSERT_EQ("orthodox", province.getReligion());
 	ASSERT_EQ("roman", province.getCulture());
 }

--- a/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvincesTests.cpp
+++ b/ImperatorToCK3Tests/CK3WorldTests/Province/CK3ProvincesTests.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "../ImperatorToCK3/Source/CK3/Province/CK3Provinces.h"
+#include "CK3/Province/CK3Provinces.h"
 
 
 TEST(CK3World_CK3ProvincesTests, provincesDefaltToEmpty)
@@ -15,10 +15,10 @@ TEST(CK3World_CK3ProvincesTests, provincesAreProperlyLoadedFromFile)
 	ASSERT_EQ(4, provinces.getProvinces().size());
 	ASSERT_EQ(3080, provinces.getProvinces().find(3080)->first);
 	ASSERT_EQ("slovien", provinces.getProvinces().find(3080)->second->getCulture());
-	ASSERT_EQ("slavic_pagan", provinces.getProvinces().find(3080)->second->getReligion());
+	ASSERT_EQ("catholic", provinces.getProvinces().find(3080)->second->getReligion());
 	ASSERT_EQ(4165, provinces.getProvinces().find(4165)->first);
 	ASSERT_EQ("slovien", provinces.getProvinces().find(4165)->second->getCulture());
-	ASSERT_EQ("slavic_pagan", provinces.getProvinces().find(4165)->second->getReligion());
+	ASSERT_EQ("catholic", provinces.getProvinces().find(4165)->second->getReligion());
 	ASSERT_EQ(4125, provinces.getProvinces().find(4125)->first);
 	ASSERT_EQ("czech", provinces.getProvinces().find(4125)->second->getCulture());
 	ASSERT_EQ("slavic_pagan", provinces.getProvinces().find(4125)->second->getReligion());

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
@@ -314,6 +314,18 @@
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)configurables</DestinationFolders>
     </CopyFileToFolders>
   </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\culture_map.txt">
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)configurables</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)configurables</DestinationFolders>
+    </CopyFileToFolders>
+  </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\religion_map.txt">
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)configurables</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)configurables</DestinationFolders>
+    </CopyFileToFolders>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
@@ -297,18 +297,6 @@
     <ClInclude Include="..\ImperatorToCK3\Source\Imperator\Provinces\Provinces.h" />
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="TestFiles\CK3ProvinceDetailsBlank.txt">
-      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TestFiles\CK3ProvinceDetails</DestinationFolders>
-      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TestFiles\CK3ProvinceDetails</DestinationFolders>
-    </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
-    <CopyFileToFolders Include="TestFiles\CK3ProvinceDetailsCorrect.txt">
-      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TestFiles\CK3ProvinceDetails</DestinationFolders>
-      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TestFiles\CK3ProvinceDetails</DestinationFolders>
-    </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
     <CopyFileToFolders Include="TestFiles\CK3ProvincesHistoryFile.txt">
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)TestFiles</DestinationFolders>
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)TestFiles</DestinationFolders>

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
@@ -493,5 +493,13 @@
     <CopyFileToFolders Include="TestFiles\title_map.txt">
       <Filter>TestFiles</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\culture_map.txt">
+      <Filter>TestFiles</Filter>
+    </CopyFileToFolders>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\ImperatorToCK3\Data_Files\configurables\religion_map.txt">
+      <Filter>TestFiles</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
@@ -484,12 +484,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="TestFiles\CK3ProvinceDetailsBlank.txt">
-      <Filter>TestFiles</Filter>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="TestFiles\CK3ProvinceDetailsCorrect.txt">
-      <Filter>TestFiles</Filter>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="TestFiles\CK3ProvincesHistoryFile.txt">
       <Filter>TestFiles</Filter>
     </CopyFileToFolders>

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Countries/CountriesTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Countries/CountriesTests.cpp
@@ -124,5 +124,5 @@ TEST(ImperatorWorld_CountriesTests, BrokenLinkAttemptThrowsWarning)
 	auto newLine = stringLog.find_first_of('\n');
 	stringLog = stringLog.substr(0, newLine);
 
-	ASSERT_EQ(" [WARNING] Families without definition: 10", stringLog);
+	ASSERT_EQ("   [DEBUG]     Families without definition: 10", stringLog);
 }

--- a/ImperatorToCK3Tests/TestFiles/CK3ProvinceDetailsCorrect.txt
+++ b/ImperatorToCK3Tests/TestFiles/CK3ProvinceDetailsCorrect.txt
@@ -1,5 +1,0 @@
-= {
-	religion = orthodox
-	random_param = random_stuff
-	culture = roman
-}


### PR DESCRIPTION
@Zemurin This should fix the issue with "unowned" CK3 provinces on rulers' death.