### PR TITLE
Convert non-minor Imperator Families to CK3 Dynasties

### DIFF
--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -226,6 +226,8 @@
     <ClCompile Include="Source\CK3Outputter\outCharacters.cpp" />
     <ClCompile Include="Source\CK3Outputter\outCoas.cpp" />
     <ClCompile Include="Source\CK3Outputter\outColoredEmblems.cpp" />
+    <ClCompile Include="Source\CK3Outputter\outDynasties.cpp" />
+    <ClCompile Include="Source\CK3Outputter\outDynasty.cpp" />
     <ClCompile Include="Source\CK3Outputter\outLocalization.cpp" />
     <ClCompile Include="Source\CK3Outputter\outProvince.cpp" />
     <ClCompile Include="Source\CK3Outputter\outProvinces.cpp" />
@@ -318,6 +320,8 @@
     <ClInclude Include="Source\CK3Outputter\outCharacters.h" />
     <ClInclude Include="Source\CK3Outputter\outCoas.h" />
     <ClInclude Include="Source\CK3Outputter\outColoredEmblems.h" />
+    <ClInclude Include="Source\CK3Outputter\outDynasties.h" />
+    <ClInclude Include="Source\CK3Outputter\outDynasty.h" />
     <ClInclude Include="Source\CK3Outputter\outLocalization.h" />
     <ClInclude Include="Source\CK3Outputter\outProvince.h" />
     <ClInclude Include="Source\CK3Outputter\outProvinces.h" />

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -234,6 +234,7 @@
     <ClCompile Include="Source\CK3Outputter\outVersion.cpp" />
     <ClCompile Include="Source\CK3\Character\CK3Character.cpp" />
     <ClCompile Include="Source\CK3\CK3World.cpp" />
+    <ClCompile Include="Source\CK3\Dynasties\Dynasty.cpp" />
     <ClCompile Include="Source\CK3\Province\CK3Province.cpp" />
     <ClCompile Include="Source\CK3\Province\CK3ProvinceMappings.cpp" />
     <ClCompile Include="Source\CK3\Province\ProvinceDetails.cpp" />
@@ -259,6 +260,7 @@
     <ClCompile Include="Source\Imperator\Countries\CountryFactory.cpp" />
     <ClCompile Include="Source\Imperator\Countries\CountryName.cpp" />
     <ClCompile Include="Source\Imperator\Families\Families.cpp" />
+    <ClCompile Include="Source\Imperator\Families\Family.cpp" />
     <ClCompile Include="Source\Imperator\Families\FamilyFactory.cpp" />
     <ClCompile Include="Source\Imperator\Genes\AccessoryGenes.cpp" />
     <ClCompile Include="Source\Imperator\Genes\AccessoryGene.cpp" />
@@ -324,6 +326,7 @@
     <ClInclude Include="Source\CK3Outputter\outVersion.h" />
     <ClInclude Include="Source\CK3\Character\CK3Character.h" />
     <ClInclude Include="Source\CK3\CK3World.h" />
+    <ClInclude Include="Source\CK3\Dynasties\Dynasty.h" />
     <ClInclude Include="Source\CK3\Province\CK3Province.h" />
     <ClInclude Include="Source\CK3\Province\CK3ProvinceMappings.h" />
     <ClInclude Include="Source\CK3\Province\ProvinceDetails.h" />

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
@@ -385,6 +385,12 @@
     <ClInclude Include="Source\CK3\Dynasties\Dynasty.h">
       <Filter>CK3\Dynasties</Filter>
     </ClInclude>
+    <ClInclude Include="Source\CK3Outputter\outDynasties.h">
+      <Filter>CK3Outputter</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\CK3Outputter\outDynasty.h">
+      <Filter>CK3Outputter</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\main.cpp" />
@@ -648,6 +654,12 @@
       <Filter>CK3\Dynasties</Filter>
     </ClCompile>
     <ClCompile Include="Source\Imperator\Families\Family.cpp" />
+    <ClCompile Include="Source\CK3Outputter\outDynasties.cpp">
+      <Filter>CK3Outputter</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\CK3Outputter\outDynasty.cpp">
+      <Filter>CK3Outputter</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="Resources\rakaly.dll">

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
@@ -43,9 +43,6 @@
     <Filter Include="Mappers\ProvinceMapper">
       <UniqueIdentifier>{98c970e3-6c0d-4b8b-b141-6d4519c3b82e}</UniqueIdentifier>
     </Filter>
-    <Filter Include="CK3\Province">
-      <UniqueIdentifier>{8d84171d-cbd1-49e5-aba5-9b0fc315fab3}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Mappers\CultureMapper">
       <UniqueIdentifier>{df9c7661-79c3-4254-969a-6231753b31ac}</UniqueIdentifier>
     </Filter>
@@ -69,9 +66,6 @@
     </Filter>
     <Filter Include="Resources">
       <UniqueIdentifier>{08765932-f1d7-433c-8037-80b2fd4a62f1}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="CK3\Character">
-      <UniqueIdentifier>{532b7914-6ab3-42c7-9090-371686001d99}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mappers\TraitMapper">
       <UniqueIdentifier>{c0c8fb12-dab8-4549-812a-d7fc79f7cc51}</UniqueIdentifier>
@@ -102,6 +96,15 @@
     </Filter>
     <Filter Include="CommonUtilities">
       <UniqueIdentifier>{39355f0a-c912-40f8-9c6d-2044fbe02368}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="CK3\Dynasties">
+      <UniqueIdentifier>{19877fab-2869-4a15-8620-e8e0b7c90166}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="CK3\Characters">
+      <UniqueIdentifier>{532b7914-6ab3-42c7-9090-371686001d99}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="CK3\Provinces">
+      <UniqueIdentifier>{8d84171d-cbd1-49e5-aba5-9b0fc315fab3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -221,10 +224,10 @@
       <Filter>CK3Outputter</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3\Province\CK3Province.h">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3\Province\ProvinceDetails.h">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClInclude>
     <ClInclude Include="Source\Mappers\CultureMapper\CultureMapper.h">
       <Filter>Mappers\CultureMapper</Filter>
@@ -239,10 +242,10 @@
       <Filter>Mappers\ReligionMapper</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3\Province\CK3Provinces.h">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3\Province\CK3ProvinceMappings.h">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3Outputter\outProvinces.h">
       <Filter>CK3Outputter</Filter>
@@ -293,7 +296,7 @@
       <Filter>CK3Outputter</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3\Character\CK3Character.h">
-      <Filter>CK3\Character</Filter>
+      <Filter>CK3\Characters</Filter>
     </ClInclude>
     <ClInclude Include="Source\CK3\Titles\TitlesHistory.h">
       <Filter>CK3\Titles</Filter>
@@ -378,6 +381,9 @@
     </ClInclude>
     <ClInclude Include="Source\CommonUtilities\SimpleField.h">
       <Filter>CommonUtilities</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\CK3\Dynasties\Dynasty.h">
+      <Filter>CK3\Dynasties</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -495,10 +501,10 @@
       <Filter>CK3Outputter</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3\Province\CK3Province.cpp">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3\Province\ProvinceDetails.cpp">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClCompile>
     <ClCompile Include="Source\Mappers\CultureMapper\CultureMapper.cpp">
       <Filter>Mappers\CultureMapper</Filter>
@@ -516,10 +522,10 @@
       <Filter>CK3</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3\Province\CK3Provinces.cpp">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3\Province\CK3ProvinceMappings.cpp">
-      <Filter>CK3\Province</Filter>
+      <Filter>CK3\Provinces</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3Outputter\outProvinces.cpp">
       <Filter>CK3Outputter</Filter>
@@ -561,7 +567,7 @@
       <Filter>CK3Outputter</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3\Character\CK3Character.cpp">
-      <Filter>CK3\Character</Filter>
+      <Filter>CK3\Characters</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3\Titles\TitlesHistory.cpp">
       <Filter>CK3\Titles</Filter>
@@ -638,6 +644,10 @@
     <ClCompile Include="Source\CommonUtilities\SimpleField.cpp">
       <Filter>CommonUtilities</Filter>
     </ClCompile>
+    <ClCompile Include="Source\CK3\Dynasties\Dynasty.cpp">
+      <Filter>CK3\Dynasties</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Imperator\Families\Family.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="Resources\rakaly.dll">

--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -51,6 +51,8 @@ CK3::World::World(const Imperator::World& impWorld, const Configuration& theConf
 	linkSpouses();
 	linkMothersAndFathers();
 
+	importImperatorFamilies(impWorld);
+
 
 	addHoldersAndHistoryToTitles(impWorld);
 	removeInvalidLandlessTitles();
@@ -79,8 +81,8 @@ void CK3::World::importImperatorCountries(const Imperator::World& impWorld)
 {
 	LOG(LogLevel::Info) << "-> Importing Imperator Countries";
 
-	// countries holds all tags imported from CK3. We'll now overwrite some and
-	// add new ones from ck2 titles.
+	// landedTitles holds all titles imported from CK3. We'll now overwrite some and
+	// add new ones from Imperator tags.
 	for (const auto& title : impWorld.getCountries())
 	{
 		importImperatorCountry(title);
@@ -395,4 +397,19 @@ void CK3::World::linkMothersAndFathers()
 		}
 	}
 	Log(LogLevel::Info) << "<> " << counterMother << " mothers and " << counterFather << " fathers linked in CK3.";
+}
+
+void CK3::World::importImperatorFamilies(const Imperator::World& impWorld) {
+	LOG(LogLevel::Info) << "-> Importing Imperator Families";
+
+	// dynasties only holds dynasties converted from Imperator families, as vanilla ones aren't modified
+	for (const auto& [_, family] : impWorld.getFamilies())
+	{
+		if (family->isMinor())
+			continue;
+
+		auto newDynasty = std::make_shared<Dynasty>(family, localizationMapper);
+		dynasties.emplace(newDynasty->getID(), newDynasty);
+	}
+	LOG(LogLevel::Info) << ">> " << dynasties.size() << " total families imported.";
 }

--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -408,7 +408,7 @@ void CK3::World::importImperatorFamilies(const Imperator::World& impWorld) {
 		if (family->isMinor())
 			continue;
 
-		auto newDynasty = std::make_shared<Dynasty>(family, localizationMapper);
+		auto newDynasty = std::make_shared<Dynasty>(*family, localizationMapper);
 		dynasties.emplace(newDynasty->getID(), newDynasty);
 	}
 	LOG(LogLevel::Info) << ">> " << dynasties.size() << " total families imported.";

--- a/ImperatorToCK3/Source/CK3/CK3World.h
+++ b/ImperatorToCK3/Source/CK3/CK3World.h
@@ -3,20 +3,21 @@
 
 
 
-#include "../Imperator/ImperatorWorld.h"
-#include "../Mappers/VersionParser/VersionParser.h"
-#include "../Mappers/LocalizationMapper/LocalizationMapper.h"
-#include "../Mappers/TagTitleMapper/TagTitleMapper.h"
-#include "../Mappers/CultureMapper/CultureMapper.h"
-#include "../Mappers/ReligionMapper/ReligionMapper.h"
-#include "../Mappers/ProvinceMapper/ProvinceMapper.h"
-#include "../Mappers/CoaMapper/CoaMapper.h"
-#include "../Mappers/TraitMapper/TraitMapper.h"
-#include "../Mappers/NicknameMapper/NicknameMapper.h"
-#include "../Mappers/GovernmentMapper/GovernmentMapper.h"
-#include "../Mappers/RegionMapper/CK3RegionMapper.h"
-#include "../Mappers/RegionMapper/ImperatorRegionMapper.h"
+#include "Imperator/ImperatorWorld.h"
+#include "Mappers/VersionParser/VersionParser.h"
+#include "Mappers/LocalizationMapper/LocalizationMapper.h"
+#include "Mappers/TagTitleMapper/TagTitleMapper.h"
+#include "Mappers/CultureMapper/CultureMapper.h"
+#include "Mappers/ReligionMapper/ReligionMapper.h"
+#include "Mappers/ProvinceMapper/ProvinceMapper.h"
+#include "Mappers/CoaMapper/CoaMapper.h"
+#include "Mappers/TraitMapper/TraitMapper.h"
+#include "Mappers/NicknameMapper/NicknameMapper.h"
+#include "Mappers/GovernmentMapper/GovernmentMapper.h"
+#include "Mappers/RegionMapper/CK3RegionMapper.h"
+#include "Mappers/RegionMapper/ImperatorRegionMapper.h"
 #include "Character/CK3Character.h"
+#include "Dynasties/Dynasty.h"
 #include "Province/CK3Province.h"
 #include "Titles/LandedTitles.h"
 #include "Titles/Title.h"
@@ -35,6 +36,7 @@ class World
 		World(const Imperator::World& impWorld, const Configuration& theConfiguration, const mappers::VersionParser& versionParser);
 
 		[[nodiscard]] const auto& getCharacters() const { return characters; }
+		[[nodiscard]] const auto& getDynasties() const { return dynasties; }
 		[[nodiscard]] const auto& getTitles() const { return landedTitles.getTitles(); }
 		[[nodiscard]] const auto& getProvinces() const { return provinces; }
 
@@ -43,6 +45,8 @@ class World
 		void importImperatorCharacter(const std::pair<unsigned long long, std::shared_ptr<Imperator::Character>>& character, bool ConvertBirthAndDeathDates, date endDate);
 		void linkSpouses();
 		void linkMothersAndFathers();
+
+		void importImperatorFamilies(const Imperator::World& impWorld);
 	
 		void importImperatorCountries(const Imperator::World& impWorld);
 		void importImperatorCountry(const std::pair<unsigned long long, std::shared_ptr<Imperator::Country>>& country);
@@ -58,6 +62,7 @@ class World
 
 
 		std::map<std::string, std::shared_ptr<Character>> characters;
+		std::map<std::string, std::shared_ptr<Dynasty>> dynasties;
 		LandedTitles landedTitles;
 		std::map<unsigned long long, std::shared_ptr<Province>> provinces;
 

--- a/ImperatorToCK3/Source/CK3/Character/CK3Character.h
+++ b/ImperatorToCK3/Source/CK3/Character/CK3Character.h
@@ -19,6 +19,7 @@ namespace mappers
 
 namespace CK3
 {
+class Dynasty;
 class Character
 {
   public:
@@ -39,6 +40,7 @@ class Character
 	void setMother(const std::pair<std::string, std::shared_ptr<Character>>& theMother) { mother = theMother; }
 	void setFather(const std::pair<std::string, std::shared_ptr<Character>>& theFather) { father = theFather; }
 	void addChild(const std::pair<std::string, std::shared_ptr<Character>>& theChild) { children.insert(theChild); }
+	void setDynastyID(const std::string& dynID) { dynastyID = dynID; }
 
 	friend std::ostream& operator<<(std::ostream& output, const Character& character);
 
@@ -63,6 +65,8 @@ class Character
 	std::pair<std::string, std::shared_ptr<Character>> father;
 	std::map<std::string, std::shared_ptr<Character>> children;
 	std::map<std::string, std::shared_ptr<Character>> spouses;
+
+	std::optional<std::string> dynastyID; // not always set
 };
 } // namespace CK3
 

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
@@ -6,15 +6,12 @@
 
 
 
-CK3::Dynasty::Dynasty(const Imperator::Family& impFamily, const mappers::LocalizationMapper& locMapper) {
-	ID = "dynn_IMPTOCK3_" + std::to_string(impFamily.getID());
+CK3::Dynasty::Dynasty(const Imperator::Family& impFamily, const mappers::LocalizationMapper& locMapper) : ID{"dynn_IMPTOCK3_" + std::to_string(impFamily.getID())} {
 	name = ID;
 
 	const auto& impMembers = impFamily.getMembers();
 	if (!impMembers.empty()) {
-		// set culture
-		auto impHead = impMembers[0].second;
-		culture = impHead->getCK3Character()->culture;
+		culture = impMembers[0].second->getCK3Character()->culture; // make head's culture the dynasty culture
 	}
 	else {
 		Log(LogLevel::Warning) << "Couldn't determine culture for dynasty " << ID << ", needs manual setting!";

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
@@ -6,20 +6,19 @@
 
 
 
-CK3::Dynasty::Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const mappers::LocalizationMapper& locMapper) {
-	const auto& impMembers = impFamily->getMembers();
+CK3::Dynasty::Dynasty(const Imperator::Family& impFamily, const mappers::LocalizationMapper& locMapper) {
+	ID = "dynn_IMPTOCK3_" + std::to_string(impFamily.getID());
+	name = ID;
 
+	const auto& impMembers = impFamily.getMembers();
 	if (!impMembers.empty()) {
 		// set culture
 		auto impHead = impMembers[0].second;
 		culture = impHead->getCK3Character()->culture;
 	}
 	else {
-		Log(LogLevel::Warning) << "Couldn't determine culture for dynasty from Imperator family " << impFamily->getID() << " " << impFamily->getKey() << ", needs manual setting!";
+		Log(LogLevel::Warning) << "Couldn't determine culture for dynasty " << ID << ", needs manual setting!";
 	}
-
-	ID = "dynn_IMPTOCK3_" + std::to_string(impFamily->getID());
-	name = ID;
 
 	for (const auto& [memberID, member] : impMembers) {
 		if (const auto& ck3Member = member->getCK3Character()) {
@@ -27,7 +26,7 @@ CK3::Dynasty::Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const
 		}
 	}
 
-	const auto& impFamilyLocKey = impFamily->getKey();
+	const auto& impFamilyLocKey = impFamily.getKey();
 	auto impFamilyLoc = locMapper.getLocBlockForKey(impFamilyLocKey);
 	if (impFamilyLoc) {
 		localization = std::pair(name, *impFamilyLoc);

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
@@ -10,6 +10,7 @@ CK3::Dynasty::Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const
 	const auto& impMembers = impFamily->getMembers();
 
 	if (!impMembers.empty()) {
+		// set culture
 		auto impHead = impMembers[0].second;
 		culture = impHead->getCK3Character()->culture;
 	}
@@ -19,6 +20,12 @@ CK3::Dynasty::Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const
 
 	ID = "dynn_IMPTOCK3_" + std::to_string(impFamily->getID());
 	name = ID;
+
+	for (const auto& [memberID, member] : impMembers) {
+		if (const auto& ck3Member = member->getCK3Character()) {
+			ck3Member->setDynastyID(ID);
+		}
+	}
 
 	const auto& impFamilyLocKey = impFamily->getKey();
 	auto impFamilyLoc = locMapper.getLocBlockForKey(impFamilyLocKey);

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
@@ -1,0 +1,26 @@
+#include "Dynasty.h"
+#include "CK3/Character/CK3Character.h"
+#include "Imperator/Families/Family.h"
+#include "Imperator/Characters/Character.h"
+#include "Log.h"
+
+
+
+CK3::Dynasty::Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const mappers::LocalizationMapper& locMapper) {
+	const auto& impMembers = impFamily->getMembers();
+	if (!impMembers.empty()) {
+		auto impHead = impMembers[0].second;
+		culture = impHead->getCK3Character()->culture;
+	}
+	ID = "dynn_IMPTOCK3_" + std::to_string(impFamily->getID());
+	name = ID;
+
+	const auto& impFamilyLocKey = impFamily->getKey();
+	auto impFamilyLoc = locMapper.getLocBlockForKey(impFamilyLocKey);
+	if (impFamilyLoc) {
+		localization = std::pair(name, *impFamilyLoc);
+	}
+	else { // fallback: use unlocalized Imperator family key
+		localization = std::pair(name, mappers::LocBlock{ impFamilyLocKey,impFamilyLocKey,impFamilyLocKey,impFamilyLocKey,impFamilyLocKey });
+	}
+}

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
@@ -8,10 +8,15 @@
 
 CK3::Dynasty::Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const mappers::LocalizationMapper& locMapper) {
 	const auto& impMembers = impFamily->getMembers();
+
 	if (!impMembers.empty()) {
 		auto impHead = impMembers[0].second;
 		culture = impHead->getCK3Character()->culture;
 	}
+	else {
+		Log(LogLevel::Warning) << "Couldn't determine culture for dynasty from Imperator family " << impFamily->getID() << " " << impFamily->getKey() << ", needs manual setting!";
+	}
+
 	ID = "dynn_IMPTOCK3_" + std::to_string(impFamily->getID());
 	name = ID;
 

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.h
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.h
@@ -16,7 +16,7 @@ namespace CK3 {
 
 class Dynasty {
 public:
-	Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const mappers::LocalizationMapper& locMapper);
+	Dynasty(const Imperator::Family& impFamily, const mappers::LocalizationMapper& locMapper);
 
 	[[nodiscard]] const auto& getID() const { return ID; }
 	[[nodiscard]] const auto& getName() const { return name; }

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.h
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.h
@@ -1,0 +1,34 @@
+#ifndef CK3_DYNASTY_H
+#define CK3_DYNASTY_H
+
+
+
+#include "Mappers/LocalizationMapper/LocalizationMapper.h"
+#include <memory>
+
+
+
+namespace Imperator {
+class Family;
+}
+
+namespace CK3 {
+
+class Dynasty {
+public:
+	Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const mappers::LocalizationMapper& locMapper);
+
+	[[nodiscard]] const auto& getID() const { return ID; }
+	[[nodiscard]] const auto& getLocalization() const { return localization; }
+
+private:
+	std::string ID;
+	std::string name;
+	std::optional<std::string> culture;
+
+	std::pair<std::string, mappers::LocBlock> localization;
+};
+
+} // namespace CK3
+
+#endif // CK3_DYNASTY_H

--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.h
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.h
@@ -19,12 +19,16 @@ public:
 	Dynasty(const std::shared_ptr<Imperator::Family>& impFamily, const mappers::LocalizationMapper& locMapper);
 
 	[[nodiscard]] const auto& getID() const { return ID; }
+	[[nodiscard]] const auto& getName() const { return name; }
+	[[nodiscard]] const auto& getCulture() const { return culture; }
 	[[nodiscard]] const auto& getLocalization() const { return localization; }
+
+	friend std::ostream& operator<<(std::ostream& output, const Dynasty& dynasty);
 
 private:
 	std::string ID;
 	std::string name;
-	std::optional<std::string> culture;
+	std::string culture;
 
 	std::pair<std::string, mappers::LocBlock> localization;
 };

--- a/ImperatorToCK3/Source/CK3Outputter/CK3WorldOutputter.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/CK3WorldOutputter.cpp
@@ -91,6 +91,11 @@ void CK3::createFolders(const std::string& outputName)
 	commonItems::TryCreateFolder("output/" + outputName + "/common/coat_of_arms/coat_of_arms");
 	commonItems::TryCreateFolder("output/" + outputName + "/localization");
 	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace");
+	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace/english");
+	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace/french");
+	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace/german");
+	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace/russian");
+	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace/spanish");
 	commonItems::TryCreateFolder("output/" + outputName + "/gfx");
 	commonItems::TryCreateFolder("output/" + outputName + "/gfx/coat_of_arms");
 	commonItems::TryCreateFolder("output/" + outputName + "/gfx/coat_of_arms/colored_emblems");

--- a/ImperatorToCK3/Source/CK3Outputter/CK3WorldOutputter.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/CK3WorldOutputter.cpp
@@ -6,13 +6,14 @@
 #include "outCoas.h"
 #include "outLocalization.h"
 #include "outCharacters.h"
+#include "outDynasties.h"
 #include "outProvinces.h"
 #include "outTitles.h"
 #include "outColoredEmblems.h"
 
 
-namespace CK3
-{
+
+namespace CK3 {
 
 void outputModFile(const std::string& outputName);
 void createModFolder(const std::string& outputName);
@@ -21,8 +22,7 @@ void createFolders(const std::string& outputName);
 }
 
 
-void CK3::outputWorld(const World& CK3World, const Configuration& theConfiguration)
-{
+void CK3::outputWorld(const World& CK3World, const Configuration& theConfiguration) {
 	LOG(LogLevel::Info) << "<- Clearing the output mod folder";
 	std::filesystem::remove_all("output/" + theConfiguration.getOutputModName());
 	
@@ -35,6 +35,9 @@ void CK3::outputWorld(const World& CK3World, const Configuration& theConfigurati
 
 	LOG(LogLevel::Info) << "<- Writing Characters";
 	outputCharacters(outputName, CK3World.getCharacters());
+
+	LOG(LogLevel::Info) << "<- Writing Dynasties";
+	outputDynasties(outputName, CK3World.getDynasties());
 	
 	LOG(LogLevel::Info) << "<- Writing Provinces";
 	outputHistoryProvinces(outputName, CK3World.getProvinces());
@@ -58,8 +61,7 @@ void CK3::outputWorld(const World& CK3World, const Configuration& theConfigurati
 }
 
 
-void CK3::outputModFile(const std::string& outputName)
-{
+void CK3::outputModFile(const std::string& outputName) {
 	std::ofstream modFile{ "output/" + outputName + ".mod" };
 	modFile << "name = \"Converted - " << outputName << "\"\n";
 	modFile << "path = \"mod/" << outputName << "\"\n";
@@ -70,14 +72,12 @@ void CK3::outputModFile(const std::string& outputName)
 }
 
 
-void CK3::createModFolder(const std::string& outputName)
-{
+void CK3::createModFolder(const std::string& outputName) {
 	const std::filesystem::path modPath{ "output/" + outputName };
 	std::filesystem::create_directories(modPath);
 }
 
-void CK3::createFolders(const std::string& outputName)
-{
+void CK3::createFolders(const std::string& outputName) {
 	commonItems::TryCreateFolder("output/" + outputName + "/history");
 	commonItems::TryCreateFolder("output/" + outputName + "/history/titles");
 	commonItems::TryCreateFolder("output/" + outputName + "/history/titles/replace");
@@ -85,10 +85,11 @@ void CK3::createFolders(const std::string& outputName)
 	commonItems::TryCreateFolder("output/" + outputName + "/history/provinces");
 	commonItems::TryCreateFolder("output/" + outputName + "/history/province_mapping");
 	commonItems::TryCreateFolder("output/" + outputName + "/common");
-	commonItems::TryCreateFolder("output/" + outputName + "/common/landed_titles");
-	commonItems::TryCreateFolder("output/" + outputName + "/common/named_colors");
 	commonItems::TryCreateFolder("output/" + outputName + "/common/coat_of_arms");
 	commonItems::TryCreateFolder("output/" + outputName + "/common/coat_of_arms/coat_of_arms");
+	commonItems::TryCreateFolder("output/" + outputName + "/common/dynasties");
+	commonItems::TryCreateFolder("output/" + outputName + "/common/landed_titles");
+	commonItems::TryCreateFolder("output/" + outputName + "/common/named_colors");
 	commonItems::TryCreateFolder("output/" + outputName + "/localization");
 	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace");
 	commonItems::TryCreateFolder("output/" + outputName + "/localization/replace/english");
@@ -100,5 +101,4 @@ void CK3::createFolders(const std::string& outputName)
 	commonItems::TryCreateFolder("output/" + outputName + "/gfx/coat_of_arms");
 	commonItems::TryCreateFolder("output/" + outputName + "/gfx/coat_of_arms/colored_emblems");
 	commonItems::TryCreateFolder("output/" + outputName + "/gfx/coat_of_arms/patterns");
-
 }

--- a/ImperatorToCK3/Source/CK3Outputter/outCharacter.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outCharacter.cpp
@@ -1,14 +1,24 @@
 #include "outCharacter.h"
+#include "CK3/Dynasties/Dynasty.h"
+
 
 
 std::ostream& CK3::operator<<(std::ostream& output, const Character& character)
 {
 	// output ID, name, sex, culture, religion
 	output << character.ID << " = {\n";
-	if (!character.name.empty()) output << "\tname = \"" << character.name << "\"\n";
-	if (character.female) output << "\tfemale = yes\n";
-	if (!character.culture.empty()) output << "\tculture = " << character.culture << "\n";
-	if (!character.religion.empty()) output << "\treligion = " << character.religion << "\n";
+	if (!character.name.empty())
+		output << "\tname = \"" << character.name << "\"\n";
+	if (character.female)
+		output << "\tfemale = yes\n";
+	if (!character.culture.empty())
+		output << "\tculture = " << character.culture << "\n";
+	if (!character.religion.empty())
+		output << "\treligion = " << character.religion << "\n";
+
+	// output dynasty
+	if (character.dynastyID)
+		output << "\tdynasty = " << *character.dynastyID << "\n";
 
 	//output father and mother
 	if (character.father.second) output << "\tfather = " << character.father.first << "\n";

--- a/ImperatorToCK3/Source/CK3Outputter/outCharacters.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outCharacters.cpp
@@ -8,8 +8,7 @@ void CK3::outputCharacters(const std::string& outputModName, const std::map<std:
 {
 	std::ofstream output("output/" + outputModName + "/history/characters/fromImperator.txt"); // dumping all into one file
 	if (!output.is_open())
-		throw std::runtime_error(
-			"Could not create landed titles file: output/" + outputModName + "/history/characters/fromImperator.txt");
+		throw std::runtime_error("Could not create characters file: output/" + outputModName + "/history/characters/fromImperator.txt");
 	output << commonItems::utf8BOM;
 	for (const auto& [id, character] : characters)
 	{

--- a/ImperatorToCK3/Source/CK3Outputter/outDynasties.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outDynasties.cpp
@@ -13,7 +13,7 @@ void CK3::outputDynasties(const std::string& outputModName, const std::map<std::
 		throw std::runtime_error("Could not create dynasties file: " + outputPath);
 	}
 	output << commonItems::utf8BOM;
-	for (const auto& [id, dynasty] : dynasties) {
+	for (const auto& [unused, dynasty] : dynasties) {
 		output << *dynasty;
 	}
 	output.close();

--- a/ImperatorToCK3/Source/CK3Outputter/outDynasties.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outDynasties.cpp
@@ -1,0 +1,20 @@
+#include "outDynasties.h"
+#include "CK3/Dynasties/Dynasty.h"
+#include <filesystem>
+#include <fstream>
+#include "CommonFunctions.h"
+
+
+
+void CK3::outputDynasties(const std::string& outputModName, const std::map<std::string, std::shared_ptr<Dynasty>>& dynasties) {
+	std::string outputPath = "output/" + outputModName + "/common/dynasties/imp_dynasties.txt";
+	std::ofstream output(outputPath); // dumping all into one file
+	if (!output.is_open()) {
+		throw std::runtime_error("Could not create dynasties file: " + outputPath);
+	}
+	output << commonItems::utf8BOM;
+	for (const auto& [id, dynasty] : dynasties) {
+		output << *dynasty;
+	}
+	output.close();
+}

--- a/ImperatorToCK3/Source/CK3Outputter/outDynasties.h
+++ b/ImperatorToCK3/Source/CK3Outputter/outDynasties.h
@@ -1,0 +1,21 @@
+#ifndef CK3_OUT_DYNASTIES_H
+#define CK3_OUT_DYNASTIES_H
+
+
+
+#include <map>
+#include <memory>
+#include <string>
+
+
+
+namespace CK3 {
+
+class Dynasty;
+void outputDynasties(const std::string& outputModName, const std::map<std::string, std::shared_ptr<Dynasty>>& dynasties);
+
+}
+
+
+
+#endif // CK3_OUT_DYNASTIES_H

--- a/ImperatorToCK3/Source/CK3Outputter/outDynasty.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outDynasty.cpp
@@ -1,0 +1,14 @@
+#include "outDynasty.h"
+#include "CK3/Dynasties/Dynasty.h"
+
+
+
+std::ostream& CK3::operator<<(std::ostream& output, const Dynasty& dynasty) {
+	// output ID, name and culture
+	output << dynasty.ID << " = {\n";
+	output << "\tname = \"" << dynasty.name << "\"\n";
+	output << "\tculture = " << dynasty.culture << "\n";
+	output << "}\n";
+	
+	return output;
+}

--- a/ImperatorToCK3/Source/CK3Outputter/outDynasty.h
+++ b/ImperatorToCK3/Source/CK3Outputter/outDynasty.h
@@ -1,0 +1,18 @@
+#ifndef OUT_DYNASTY_H
+#define OUT_DYNASTY_H
+
+
+
+#include <ostream>
+
+
+
+namespace CK3 {
+
+class Dynasty;
+std::ostream& operator<<(std::ostream& output, const Dynasty& dynasty);
+
+}
+
+
+#endif // OUT_DYNASTY_H

--- a/ImperatorToCK3/Source/CK3Outputter/outLocalization.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outLocalization.cpp
@@ -4,26 +4,28 @@
 #include "../commonItems/OSCompatibilityLayer.h"
 #include "../commonItems/CommonFunctions.h"
 
-void CK3::outputLocalization(const std::string& imperatorPath, const std::string& outputName, const World& CK3World)
-{
+
+
+void CK3::outputLocalization(const std::string& imperatorPath, const std::string& outputName, const World& CK3World) {
 	// copy character/family names localization
 	commonItems::TryCopyFile(imperatorPath + "/game/localization/english/character_names_l_english.yml",
-		"output/" + outputName + "/localization/replace/IMPERATOR_character_names_l_english.yml");
+		"output/" + outputName + "/localization/replace/english/IMPERATOR_character_names_l_english.yml");
 	commonItems::TryCopyFile(imperatorPath + "/game/localization/french/character_names_l_french.yml",
-		"output/" + outputName + "/localization/replace/IMPERATOR_character_names_l_french.yml");
+		"output/" + outputName + "/localization/replace/french/IMPERATOR_character_names_l_french.yml");
 	commonItems::TryCopyFile(imperatorPath + "/game/localization/german/character_names_l_german.yml",
-		"output/" + outputName + "/localization/replace/IMPERATOR_character_names_l_german.yml");
+		"output/" + outputName + "/localization/replace/german/IMPERATOR_character_names_l_german.yml");
 	commonItems::TryCopyFile(imperatorPath + "/game/localization/russian/character_names_l_russian.yml",
-		"output/" + outputName + "/localization/replace/IMPERATOR_character_names_l_russian.yml");
+		"output/" + outputName + "/localization/replace/russian/IMPERATOR_character_names_l_russian.yml");
 	commonItems::TryCopyFile(imperatorPath + "/game/localization/spanish/character_names_l_spanish.yml",
-		"output/" + outputName + "/localization/replace/IMPERATOR_character_names_l_spanish.yml");
+		"output/" + outputName + "/localization/replace/spanish/IMPERATOR_character_names_l_spanish.yml");
 
 	
-	std::ofstream english("output/" + outputName + "/localization/replace/converter_l_english.yml");
-	std::ofstream french("output/" + outputName + "/localization/replace/converter_l_french.yml");
-	std::ofstream german("output/" + outputName + "/localization/replace/converter_l_german.yml");
-	std::ofstream russian("output/" + outputName + "/localization/replace/converter_l_russian.yml");
-	std::ofstream spanish("output/" + outputName + "/localization/replace/converter_l_spanish.yml");
+	std::ofstream english("output/" + outputName + "/localization/replace/english/converter_l_english.yml");
+	std::ofstream french("output/" + outputName + "/localization/replace/french/converter_l_french.yml");
+	std::ofstream german("output/" + outputName + "/localization/replace/german/converter_l_german.yml");
+	std::ofstream russian("output/" + outputName + "/localization/replace/russian/converter_l_russian.yml");
+	std::ofstream spanish("output/" + outputName + "/localization/replace/spanish/converter_l_spanish.yml");
+
 	if (!english.is_open())
 		throw std::runtime_error("Error writing english localization file! Is the output folder writable?");
 	if (!french.is_open())
@@ -34,6 +36,7 @@ void CK3::outputLocalization(const std::string& imperatorPath, const std::string
 		throw std::runtime_error("Error writing russian localization file! Is the output folder writable?");
 	if (!spanish.is_open())
 		throw std::runtime_error("Error writing spanish localization file! Is the output folder writable?");
+
 	english << commonItems::utf8BOM << "l_english:\n";
 	french << commonItems::utf8BOM << "l_french:\n";
 	german << commonItems::utf8BOM << "l_german:\n";
@@ -41,10 +44,8 @@ void CK3::outputLocalization(const std::string& imperatorPath, const std::string
 	spanish << commonItems::utf8BOM << "l_spanish:\n";
 
 	// title localization
-	for (const auto& [unused, title] : CK3World.getTitles())
-	{
-		for (const auto& [key, loc] : title->localizations)
-		{
+	for (const auto& [_, title] : CK3World.getTitles()) {
+		for (const auto& [key, loc] : title->localizations) {
 			english << " " << key << ": \"" << loc.english << "\"\n";
 			french << " " << key << ": \"" << loc.french << "\"\n";
 			german << " " << key << ": \"" << loc.german << "\"\n";
@@ -54,25 +55,43 @@ void CK3::outputLocalization(const std::string& imperatorPath, const std::string
 	}
 	// character name localization
 	std::set<std::string> uniqueKeys;
-	for (const auto& [unused, character] : CK3World.getCharacters())
-	{
-		for (const auto& [key, loc] : character->localizations)
-		{
-			if (!uniqueKeys.contains(key))
-			{
+	for (const auto& [unused, character] : CK3World.getCharacters()) {
+		for (const auto& [key, loc] : character->localizations) {
+			if (!uniqueKeys.contains(key)) {
 				english << " " << key << ": \"" << loc.english << "\"\n";
 				french << " " << key << ": \"" << loc.french << "\"\n";
 				german << " " << key << ": \"" << loc.german << "\"\n";
 				russian << " " << key << ": \"" << loc.russian << "\"\n";
 				spanish << " " << key << ": \"" << loc.spanish << "\"\n";
 
-				uniqueKeys.insert(key);
+				uniqueKeys.emplace(key);
 			}
 		}
 	}
+
 	english.close();
 	french.close();
 	german.close();
 	russian.close();
 	spanish.close();
+
+	// dynasty localization
+	std::ofstream englishDynLoc("output/" + outputName + "/localization/replace/english/converter_l_english.yml");
+	std::ofstream frenchDynLoc("output/" + outputName + "/localization/replace/french/converter_l_french.yml");
+	std::ofstream germanDynLoc("output/" + outputName + "/localization/replace/german/converter_l_german.yml");
+	std::ofstream russianDynLoc("output/" + outputName + "/localization/replace/russian/converter_l_russian.yml");
+	std::ofstream spanishDynLoc("output/" + outputName + "/localization/replace/spanish/converter_l_spanish.yml");
+	for (const auto& [_, dynasty] : CK3World.getDynasties()) {
+		const auto& [key, loc] = dynasty->getLocalization();
+		englishDynLoc << " " << key << ": \"" << loc.english << "\"\n";
+		frenchDynLoc << " " << key << ": \"" << loc.french << "\"\n";
+		germanDynLoc << " " << key << ": \"" << loc.german << "\"\n";
+		russianDynLoc << " " << key << ": \"" << loc.russian << "\"\n";
+		spanishDynLoc << " " << key << ": \"" << loc.spanish << "\"\n";
+	}
+	englishDynLoc.close();
+	frenchDynLoc.close();
+	germanDynLoc.close();
+	russianDynLoc.close();
+	spanishDynLoc.close();
 }

--- a/ImperatorToCK3/Source/CK3Outputter/outLocalization.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outLocalization.cpp
@@ -75,12 +75,31 @@ void CK3::outputLocalization(const std::string& imperatorPath, const std::string
 	russian.close();
 	spanish.close();
 
+
 	// dynasty localization
 	std::ofstream englishDynLoc("output/" + outputName + "/localization/replace/english/imp_dynasty_l_english.yml");
 	std::ofstream frenchDynLoc("output/" + outputName + "/localization/replace/french/imp_dynasty_l_french.yml");
 	std::ofstream germanDynLoc("output/" + outputName + "/localization/replace/german/imp_dynasty_l_german.yml");
 	std::ofstream russianDynLoc("output/" + outputName + "/localization/replace/russian/imp_dynasty_l_russian.yml");
 	std::ofstream spanishDynLoc("output/" + outputName + "/localization/replace/spanish/imp_dynasty_l_spanish.yml");
+
+	if (!englishDynLoc.is_open())
+		throw std::runtime_error("Error writing english localization file! Is the output folder writable?");
+	if (!frenchDynLoc.is_open())
+		throw std::runtime_error("Error writing french localization file! Is the output folder writable?");
+	if (!germanDynLoc.is_open())
+		throw std::runtime_error("Error writing german localization file! Is the output folder writable?");
+	if (!russianDynLoc.is_open())
+		throw std::runtime_error("Error writing russian localization file! Is the output folder writable?");
+	if (!spanishDynLoc.is_open())
+		throw std::runtime_error("Error writing spanish localization file! Is the output folder writable?");
+
+	englishDynLoc << commonItems::utf8BOM << "l_english:\n";
+	frenchDynLoc << commonItems::utf8BOM << "l_french:\n";
+	germanDynLoc << commonItems::utf8BOM << "l_german:\n";
+	russianDynLoc << commonItems::utf8BOM << "l_russian:\n";
+	spanishDynLoc << commonItems::utf8BOM << "l_spanish:\n";
+
 	for (const auto& [_, dynasty] : CK3World.getDynasties()) {
 		const auto& [key, loc] = dynasty->getLocalization();
 		englishDynLoc << " " << key << ": \"" << loc.english << "\"\n";

--- a/ImperatorToCK3/Source/CK3Outputter/outLocalization.cpp
+++ b/ImperatorToCK3/Source/CK3Outputter/outLocalization.cpp
@@ -76,11 +76,11 @@ void CK3::outputLocalization(const std::string& imperatorPath, const std::string
 	spanish.close();
 
 	// dynasty localization
-	std::ofstream englishDynLoc("output/" + outputName + "/localization/replace/english/converter_l_english.yml");
-	std::ofstream frenchDynLoc("output/" + outputName + "/localization/replace/french/converter_l_french.yml");
-	std::ofstream germanDynLoc("output/" + outputName + "/localization/replace/german/converter_l_german.yml");
-	std::ofstream russianDynLoc("output/" + outputName + "/localization/replace/russian/converter_l_russian.yml");
-	std::ofstream spanishDynLoc("output/" + outputName + "/localization/replace/spanish/converter_l_spanish.yml");
+	std::ofstream englishDynLoc("output/" + outputName + "/localization/replace/english/imp_dynasty_l_english.yml");
+	std::ofstream frenchDynLoc("output/" + outputName + "/localization/replace/french/imp_dynasty_l_french.yml");
+	std::ofstream germanDynLoc("output/" + outputName + "/localization/replace/german/imp_dynasty_l_german.yml");
+	std::ofstream russianDynLoc("output/" + outputName + "/localization/replace/russian/imp_dynasty_l_russian.yml");
+	std::ofstream spanishDynLoc("output/" + outputName + "/localization/replace/spanish/imp_dynasty_l_spanish.yml");
 	for (const auto& [_, dynasty] : CK3World.getDynasties()) {
 		const auto& [key, loc] = dynasty->getLocalization();
 		englishDynLoc << " " << key << ": \"" << loc.english << "\"\n";

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
@@ -8,6 +8,7 @@
 #include <set>
 
 
+
 Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB): genes(genesDB)
 {
 	registerKeys();
@@ -24,33 +25,26 @@ void Imperator::Characters::registerKeys()
 	registerMatcher(commonItems::catchallRegexMatch, commonItems::ignoreItem);
 }
 
-void Imperator::Characters::linkFamilies(const Families& theFamilies)
-{
+void Imperator::Characters::linkFamilies(const Families& theFamilies) {
 	auto counter = 0;
 	std::set<unsigned long long> idsWithoutDefinition;
 	const auto& families = theFamilies.getFamilies();
-	for (const auto& [characterID, character]: characters)
-	{
-		if (character->getFamily().first)
-		{
-			const auto& familyItr = families.find(character->getFamily().first);
-			if (familyItr != families.end())
-			{
-				character->setFamily(familyItr->second);
-				counter++;
-			}
-			else
-			{
-				idsWithoutDefinition.insert(character->getFamily().first);
-			}
+
+	for (const auto& [characterID, character]: characters) {
+		auto familyID = character->getFamily().first;
+		if (const auto& familyItr = families.find(familyID); familyItr != families.end()) {
+			character->setFamily(familyItr->second);
+			familyItr->second->linkMember(character);
+			++counter;
+		}
+		else {
+			idsWithoutDefinition.emplace(familyID);
 		}
 	}
 
 	std::string warningString = "Families without definition:";
-	if (!idsWithoutDefinition.empty())
-	{
-		for (auto id : idsWithoutDefinition)
-		{
+	if (!idsWithoutDefinition.empty()) {
+		for (auto id : idsWithoutDefinition) {
 			warningString += " ";
 			warningString += std::to_string(id);
 			warningString += ",";

--- a/ImperatorToCK3/Source/Imperator/Families/Family.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.cpp
@@ -1,12 +1,20 @@
 #include "Family.h"
 #include "Imperator/Characters/Character.h"
+#include "Log.h"
+
 
 
 void Imperator::Family::linkMember(const std::shared_ptr<Character>& newMemberPtr) {
+	if (!newMemberPtr) {
+		Log(LogLevel::Warning) << "Family " << ID << ": cannot link nullptr member!";
+		return;
+	}
 	for (auto& [memberID, memberPtr] : members) {
 		if (memberID == newMemberPtr->getID()) {
 			memberPtr = newMemberPtr;
-			break;
+			return;
 		}
 	}
+	// matching ID was not found
+	Log(LogLevel::Warning) << "Family " << ID << ": cannot link " << newMemberPtr->getID() << ": not found in members!";
 }

--- a/ImperatorToCK3/Source/Imperator/Families/Family.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.cpp
@@ -1,0 +1,12 @@
+#include "Family.h"
+#include "Imperator/Characters/Character.h"
+
+
+void Imperator::Family::linkMember(const std::shared_ptr<Character>& newMemberPtr) {
+	for (auto& [memberID, memberPtr] : members) {
+		if (memberID == newMemberPtr->getID()) {
+			memberPtr = newMemberPtr;
+			break;
+		}
+	}
+}

--- a/ImperatorToCK3/Source/Imperator/Families/Family.h
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.h
@@ -2,16 +2,21 @@
 #define IMPERATOR_FAMILY_H
 
 
+
 #include <string>
+#include <memory>
+#include <vector>
 
 
-namespace Imperator
-{
-class Family
-{
+
+namespace Imperator {
+class Character;
+class Family {
   public:
 	class Factory;
 	Family() = default;
+
+	void linkMember(const std::shared_ptr<Character>& memberPtr);
 
 	[[nodiscard]] auto getID() const { return ID; }
 	[[nodiscard]] const auto& getKey() const { return key; }
@@ -28,9 +33,10 @@ class Family
 	std::string culture;
 	double prestige = 0;
 	double prestigeRatio = 0;
-	std::vector<unsigned long long> members;
+	std::vector<std::pair<unsigned long long, std::shared_ptr<Character>>> members;
 	bool minor = false;
 };
+
 } // namespace Imperator
 
 #endif // IMPERATOR_FAMILY_H

--- a/ImperatorToCK3/Source/Imperator/Families/Family.h
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.h
@@ -13,21 +13,23 @@ class Family
 	class Factory;
 	Family() = default;
 
+	[[nodiscard]] auto getID() const { return ID; }
+	[[nodiscard]] const auto& getKey() const { return key; }
 	[[nodiscard]] const auto& getCulture() const { return culture; }
 	[[nodiscard]] const auto& getPrestige() const { return prestige; }
 	[[nodiscard]] const auto& getPrestigeRatio() const { return prestigeRatio; }
-	[[nodiscard]] const auto& getKey() const { return key; }
-	[[nodiscard]] const auto& getIsMinor() const { return isMinor; }
+	[[nodiscard]] const auto& getMembers() const { return members; }
+	[[nodiscard]] const auto& isMinor() const { return minor; }
 
-	[[nodiscard]] auto getID() const { return ID; }
 
   private:
 	unsigned long long ID = 0;
+	std::string key;
 	std::string culture;
 	double prestige = 0;
 	double prestigeRatio = 0;
-	std::string key;
-	bool isMinor = false;
+	std::vector<unsigned long long> members;
+	bool minor = false;
 };
 } // namespace Imperator
 

--- a/ImperatorToCK3/Source/Imperator/Families/FamilyFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/FamilyFactory.cpp
@@ -10,17 +10,20 @@ Imperator::Family::Factory::Factory()
 	registerKeyword("key", [&](std::istream& theStream) {
 		family->key = commonItems::getString(theStream);
 	});
-	registerKeyword("culture", [&](std::istream& theStream) {
-		family->culture = commonItems::getString(theStream);
-	});
 	registerKeyword("prestige", [&](std::istream& theStream) {
 		family->prestige = commonItems::getDouble(theStream);
 	});
 	registerKeyword("prestige_ratio", [&](std::istream& theStream) {
 		family->prestigeRatio = commonItems::getDouble(theStream);
 	});
+	registerKeyword("culture", [&](std::istream& theStream) {
+		family->culture = commonItems::getString(theStream);
+	});
 	registerKeyword("minor_family", [&](std::istream& theStream) {
-		family->isMinor = commonItems::getString(theStream) == "yes";
+		family->minor = commonItems::getString(theStream) == "yes";
+	});
+	registerKeyword("member", [&](std::istream& theStream) {
+		family->members = commonItems::getULlongs(theStream);
 	});
 	registerMatcher(commonItems::catchallRegexMatch, commonItems::ignoreItem);
 }

--- a/ImperatorToCK3/Source/Imperator/Families/FamilyFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/FamilyFactory.cpp
@@ -5,8 +5,7 @@
 
 
 
-Imperator::Family::Factory::Factory()
-{
+Imperator::Family::Factory::Factory() {
 	registerKeyword("key", [&](std::istream& theStream) {
 		family->key = commonItems::getString(theStream);
 	});
@@ -23,14 +22,15 @@ Imperator::Family::Factory::Factory()
 		family->minor = commonItems::getString(theStream) == "yes";
 	});
 	registerKeyword("member", [&](std::istream& theStream) {
-		family->members = commonItems::getULlongs(theStream);
+		for (const auto& memberID : commonItems::getULlongs(theStream)) {
+			family->members.emplace_back(memberID, nullptr);
+		}
 	});
 	registerMatcher(commonItems::catchallRegexMatch, commonItems::ignoreItem);
 }
 
 
-std::unique_ptr<Imperator::Family> Imperator::Family::Factory::getFamily(std::istream& theStream, const unsigned long long theFamilyID)
-{
+std::unique_ptr<Imperator::Family> Imperator::Family::Factory::getFamily(std::istream& theStream, const unsigned long long theFamilyID) {
 	family = std::make_unique<Family>();
 	family->ID = theFamilyID;
 

--- a/ImperatorToCK3/Source/Imperator/Families/FamilyFactory.h
+++ b/ImperatorToCK3/Source/Imperator/Families/FamilyFactory.h
@@ -9,11 +9,9 @@
 
 
 
-namespace Imperator
-{
+namespace Imperator {
 
-class Family::Factory: commonItems::convenientParser
-{
+class Family::Factory: commonItems::convenientParser {
   public:
 	explicit Factory();
 	std::unique_ptr<Family> getFamily(std::istream& theStream, unsigned long long theFamilyID);

--- a/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
+++ b/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
@@ -1,7 +1,7 @@
 #include "ImperatorWorld.h"
 #include "GameVersion.h"
-#include "../Configuration/Configuration.h"
-#include "../Helpers/rakaly_wrapper.h"
+#include "Configuration/Configuration.h"
+#include "Helpers/rakaly_wrapper.h"
 #include "Date.h"
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
@@ -11,10 +11,11 @@
 #include <filesystem>
 #include <fstream>
 
+
+
 namespace fs = std::filesystem;
 
-Imperator::World::World(const Configuration& theConfiguration)
-{
+Imperator::World::World(const Configuration& theConfiguration) {
 	LOG(LogLevel::Info) << "*** Hello Imperator, Roma Invicta! ***";
 	
 	parseGenes(theConfiguration);

--- a/ImperatorToCK3/Source/Imperator/ImperatorWorld.h
+++ b/ImperatorToCK3/Source/Imperator/ImperatorWorld.h
@@ -27,6 +27,7 @@ namespace Imperator
 			explicit World(const Configuration& theConfiguration);
 	
 			[[nodiscard]] const auto& getEndDate() const { return endDate; }
+			[[nodiscard]] const auto& getFamilies() const { return families.getFamilies(); }
 			[[nodiscard]] const auto& getCharacters() const { return characters.getCharacters(); }
 			[[nodiscard]] const auto& getProvinces() const { return provinces.getProvinces(); }
 			[[nodiscard]] const auto& getCountries() const { return countries.getCountries(); }

--- a/ImperatorToCK3Tests/CK3WorldTests/Dynasties/DynastyTests.cpp
+++ b/ImperatorToCK3Tests/CK3WorldTests/Dynasties/DynastyTests.cpp
@@ -1,0 +1,27 @@
+#include "CK3/Dynasties/Dynasty.h"
+#include "Imperator/Families/FamilyFactory.h"
+#include "Mappers/LocalizationMapper/LocalizationMapper.h"
+#include "gtest/gtest.h"
+#include <sstream>
+
+
+
+TEST(CK3World_DynastyTests, idIsProperlyConverted) {
+	std::stringstream familyStream;
+	const auto family = Imperator::Family::Factory().getFamily(familyStream, 45);
+	
+	const mappers::LocalizationMapper locMapper;
+	const CK3::Dynasty dynasty{ *family, locMapper };
+
+	ASSERT_EQ("dynn_IMPTOCK3_45", dynasty.getID());
+}
+
+TEST(CK3World_DynastyTests, nameIsProperlyConverted) {
+	std::stringstream familyStream;
+	const auto family = Imperator::Family::Factory().getFamily(familyStream, 45);
+	
+	const mappers::LocalizationMapper locMapper;
+	const CK3::Dynasty dynasty{ *family, locMapper };
+
+	ASSERT_EQ("dynn_IMPTOCK3_45", dynasty.getName());
+}

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
@@ -205,6 +205,7 @@
     <ClCompile Include="..\googletest\googlemock\src\gmock-all.cc" />
     <ClCompile Include="..\googletest\googletest\src\gtest-all.cc" />
     <ClCompile Include="..\googletest\googletest\src\gtest_main.cc" />
+    <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Families\Family.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Families\FamilyFactory.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Genes\AccessoryGene.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Genes\AccessoryGenes.cpp" />

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
@@ -172,6 +172,7 @@
     <ClCompile Include="..\commonItems\OSCommonLayer.cpp" />
     <ClCompile Include="..\commonItems\StringUtils.cpp" />
     <ClCompile Include="..\cpp-base64\base64.cpp" />
+    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Dynasties\Dynasty.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3Province.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3ProvinceMappings.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3Provinces.cpp" />
@@ -242,6 +243,7 @@
     <ClCompile Include="..\ImperatorToCK3\Source\Mappers\VersionParser\VersionParser.cpp" />
     <ClCompile Include="AccessoryGenesTests.cpp" />
     <ClCompile Include="CK3WorldTests\Character\CK3CharacterTests.cpp" />
+    <ClCompile Include="CK3WorldTests\Dynasties\DynastyTests.cpp" />
     <ClCompile Include="CK3WorldTests\Province\CK3ProvinceDetailsTests.cpp" />
     <ClCompile Include="CK3WorldTests\Province\CK3ProvincesTests.cpp" />
     <ClCompile Include="CK3WorldTests\Province\CK3ProvinceTests.cpp" />

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
@@ -459,6 +459,9 @@
     <ClCompile Include="CommonUtilitiesTests\DatedHistoryBlockTests.cpp">
       <Filter>CommonTests</Filter>
     </ClCompile>
+    <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Families\Family.cpp">
+      <Filter>Sources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ImperatorToCK3\Source\Imperator\Provinces\Province.h">
@@ -496,10 +499,6 @@
     <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\culture_map.txt">
       <Filter>TestFiles</Filter>
     </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
-    <Text Include="..\ImperatorToCK3\Data_Files\configurables\religion_map.txt">
-      <Filter>TestFiles</Filter>
-    </Text>
+    <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\religion_map.txt" />
   </ItemGroup>
 </Project>

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
@@ -94,6 +94,15 @@
     <Filter Include="Sources\CommonUtilities">
       <UniqueIdentifier>{570d630e-cc0f-4ef2-99dc-8465ff85720f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="CK3WorldTests\Dynasties">
+      <UniqueIdentifier>{f47e6a22-034e-4a27-abd8-3f73efc5b89c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Sources\CK3\Provinces">
+      <UniqueIdentifier>{c32baab6-b05b-4c7a-892c-1824bb977498}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Sources\CK3\Dynasties">
+      <UniqueIdentifier>{dfa38371-681a-46c6-8573-0583a5d3e13a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ImperatorWorldTests\Families\FamilyTests.cpp">
@@ -423,15 +432,6 @@
     <ClCompile Include="..\commonItems\StringUtils.cpp">
       <Filter>Sources\commonItems</Filter>
     </ClCompile>
-    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3Province.cpp">
-      <Filter>Sources\CK3</Filter>
-    </ClCompile>
-    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3ProvinceMappings.cpp">
-      <Filter>Sources\CK3</Filter>
-    </ClCompile>
-    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3Provinces.cpp">
-      <Filter>Sources\CK3</Filter>
-    </ClCompile>
     <ClCompile Include="..\googletest\googletest\src\gtest-all.cc">
       <Filter>Sources\gtest</Filter>
     </ClCompile>
@@ -461,6 +461,21 @@
     </ClCompile>
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Families\Family.cpp">
       <Filter>Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="CK3WorldTests\Dynasties\DynastyTests.cpp">
+      <Filter>CK3WorldTests\Dynasties</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3Province.cpp">
+      <Filter>Sources\CK3\Provinces</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3ProvinceMappings.cpp">
+      <Filter>Sources\CK3\Provinces</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Province\CK3Provinces.cpp">
+      <Filter>Sources\CK3\Provinces</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ImperatorToCK3\Source\CK3\Dynasties\Dynasty.cpp">
+      <Filter>Sources\CK3\Dynasties</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
@@ -499,6 +499,8 @@
     <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\culture_map.txt">
       <Filter>TestFiles</Filter>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\religion_map.txt" />
+    <CopyFileToFolders Include="..\ImperatorToCK3\Data_Files\configurables\religion_map.txt">
+      <Filter>TestFiles</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Families/FamilyTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Families/FamilyTests.cpp
@@ -112,7 +112,7 @@ TEST(ImperatorWorld_FamilyTests, minorFamilyDefaultsToFalse)
 
 	const auto theFamily = *Imperator::Family::Factory().getFamily(input, 42);
 
-	ASSERT_FALSE(theFamily.getIsMinor());
+	ASSERT_FALSE(theFamily.isMinor());
 }
 
 
@@ -126,7 +126,7 @@ TEST(ImperatorWorld_FamilyTests, minorFamilyCanBeSet)
 
 	const auto theFamily = *Imperator::Family::Factory().getFamily(input, 42);
 
-	ASSERT_TRUE(theFamily.getIsMinor());
+	ASSERT_TRUE(theFamily.isMinor());
 }
 
 

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Families/FamilyTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Families/FamilyTests.cpp
@@ -1,7 +1,11 @@
 #include "gtest/gtest.h"
-#include "../ImperatorToCK3/Source/Imperator/Families/Family.h"
-#include "../ImperatorToCK3/Source/Imperator/Families/FamilyFactory.h"
+#include "Imperator/Families/Family.h"
+#include "Imperator/Families/FamilyFactory.h"
+#include "Imperator/Characters/CharacterFactory.h"
+#include "Imperator/Genes/GenesDB.h"
 #include <sstream>
+
+
 
 TEST(ImperatorWorld_FamilyTests, IDCanBeSet)
 {
@@ -140,4 +144,70 @@ TEST(ImperatorWorld_FamilyTests, keyDefaultsToBlank)
 	const auto theFamily = *Imperator::Family::Factory().getFamily(input, 42);
 
 	ASSERT_TRUE(theFamily.getKey().empty());
+}
+
+TEST(ImperatorWorld_FamilyTests, membersDefaultToEmpty) {
+	std::stringstream input;
+	input << "= {}";
+
+	const auto family = *Imperator::Family::Factory().getFamily(input, 42);
+
+	ASSERT_TRUE(family.getMembers().empty());
+}
+
+TEST(ImperatorWorld_FamilyTests, linkingNullptrMemberIsLogged) {
+	std::stringstream input;
+	input << "= {}";
+
+	auto family = *Imperator::Family::Factory().getFamily(input, 42);
+
+	std::stringstream log;
+	auto* stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	family.linkMember(nullptr);
+
+	std::cout.rdbuf(stdOutBuf);
+	auto stringLog = log.str();
+	auto newLine = stringLog.find_first_of('\n');
+	stringLog = stringLog.substr(0, newLine);
+
+	ASSERT_EQ(" [WARNING] Family 42: cannot link nullptr member!", stringLog);
+}
+
+TEST(ImperatorWorld_FamilyTests, cannotLinkMemberWithoutPreexistingMatchingID) {
+	std::stringstream input;
+	input << "= { member={40 50 5} }";
+	auto family = *Imperator::Family::Factory().getFamily(input, 42);
+
+	std::stringstream charInput;
+	std::shared_ptr<Imperator::Character> character = Imperator::Character::Factory().getCharacter(charInput, "6", nullptr);
+
+	std::stringstream log;
+	auto* stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	family.linkMember(character);
+
+	std::cout.rdbuf(stdOutBuf);
+	auto stringLog = log.str();
+	auto newLine = stringLog.find_first_of('\n');
+	stringLog = stringLog.substr(0, newLine);
+
+	ASSERT_EQ(" [WARNING] Family 42: cannot link 6: not found in members!", stringLog);
+}
+
+TEST(ImperatorWorld_FamilyTests, memberLinkingWorks) {
+	std::stringstream input;
+	input << "= { member={40 50 5} }";
+	auto family = *Imperator::Family::Factory().getFamily(input, 42);
+
+	std::stringstream charInput;
+	charInput << "= { culture = kushite }";
+	auto genesDB = std::make_shared<Imperator::GenesDB>();
+	std::shared_ptr<Imperator::Character> character = Imperator::Character::Factory().getCharacter(charInput, "50", genesDB);
+
+	family.linkMember(character);
+	
+	ASSERT_EQ("kushite", family.getMembers()[1].second->getCulture());
 }


### PR DESCRIPTION
Closes #55.
Tests are missing, but checked the results in-game.