### PR TITLE
Minor refactoring: Imperator Characters and Countries

### DIFF
--- a/ImperatorToCK3/Source/Imperator/Characters/Character.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Character.cpp
@@ -1,11 +1,10 @@
-#include <utility>
 #include "Character.h"
 #include "../Families/Family.h"
+#include <utility>
 
 
 
-const std::string& Imperator::Character::getCulture() const
-{
+const std::string& Imperator::Character::getCulture() const {
 	if (!culture.empty())
 		return culture;
 	if (family.first && !family.second->getCulture().empty())
@@ -13,13 +12,14 @@ const std::string& Imperator::Character::getCulture() const
 	return culture;
 }
 
-std::string Imperator::Character::getAgeSex() const
-{
-	if (age >= 16)
-	{
-		if (female) return "female";
+
+std::string Imperator::Character::getAgeSex() const {
+	if (age >= 16) {
+		if (female)
+			return "female";
 		return "male";
 	}
-	if (female) return "girl";
+	if (female)
+		return "girl";
 	return "boy";
 }

--- a/ImperatorToCK3/Source/Imperator/Characters/Character.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/Character.h
@@ -1,18 +1,23 @@
 #ifndef IMPERATOR_CHARACTER_H
 #define IMPERATOR_CHARACTER_H
 
+
+
+#include "PortraitData.h"
 #include "Date.h"
 #include <optional>
-#include "PortraitData.h"
-#include "../Genes/GenesDB.h"
+
+
 
 namespace CK3
 {
-	class Character;
+class Character;
 } // namespace CK3
+
 namespace Imperator
 {
 class Family;
+class GenesDB;
 
 typedef struct AttributesStruct
 {

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterAttributes.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterAttributes.cpp
@@ -2,15 +2,16 @@
 #include "ParserHelpers.h"
 #include "CommonRegexes.h"
 
-Imperator::CharacterAttributes::CharacterAttributes(std::istream& theStream)
-{
+
+
+Imperator::CharacterAttributes::CharacterAttributes(std::istream& theStream) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::CharacterAttributes::registerKeys()
-{
+
+void Imperator::CharacterAttributes::registerKeys() {
 	registerKeyword("martial", [this](std::istream& theStream) {
 		martial = commonItems::getInt(theStream);
 	});

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterAttributes.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterAttributes.h
@@ -1,11 +1,15 @@
 #ifndef IMPERATOR_CHARACTER_ATTRIBUTES_H
 #define IMPERATOR_CHARACTER_ATTRIBUTES_H
+
+
+
 #include "Parser.h"
 
-namespace Imperator
-{
-class CharacterAttributes : commonItems::parser
-{
+
+
+namespace Imperator {
+
+class CharacterAttributes : commonItems::parser {
   public:
 	CharacterAttributes() = default;
 	explicit CharacterAttributes(std::istream& theStream);
@@ -23,6 +27,7 @@ class CharacterAttributes : commonItems::parser
 	int charisma = 0;
 	int zeal = 0;
 };
+
 } // namespace Imperator
 
 #endif // IMPERATOR_CHARACTER_ATTRIBUTES_H

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.cpp
@@ -7,84 +7,84 @@
 
 
 
-Imperator::Character::Factory::Factory()
-{
+Imperator::Character::Factory::Factory() {
 	registerKeyword("first_name_loc", [this](std::istream& theStream) {
 		character->name = CharacterName(theStream).getName();
-		});
+	});
 	registerKeyword("province", [this](std::istream& theStream) {
 		character->province = commonItems::getULlong(theStream);
-		});
+	});
 	registerKeyword("culture", [this](std::istream& theStream) {
 		character->culture = commonItems::getString(theStream);
-		});
+	});
 	registerKeyword("religion", [this](std::istream& theStream) {
 		character->religion = commonItems::getString(theStream);
-		});
+	});
 	registerKeyword("female", [this](std::istream& theStream) {
 		const auto femStr = commonItems::getString(theStream);
 		character->female = femStr == "yes";
-		});
+	});
 	registerKeyword("traits", [this](std::istream& theStream) {
 		character->traits = commonItems::getStrings(theStream);
-		});
+	});
 	registerKeyword("birth_date", [this](std::istream& theStream) {
 		const auto dateStr = commonItems::getString(theStream);
 		character->birthDate = date(dateStr, true); // converted to AD
-		});
+	});
 	registerKeyword("death_date", [this](std::istream& theStream) {
 		const auto dateStr = commonItems::getString(theStream);
 		character->deathDate = date(dateStr, true); // converted to AD
-		});
+	});
 	registerKeyword("age", [this](std::istream& theStream) {
 		character->age = static_cast<unsigned int>(commonItems::getInt(theStream));
-		});
+	});
 	registerKeyword("nickname", [this](std::istream& theStream) {
 		character->nickname = commonItems::getString(theStream);
-		});
+	});
 	registerKeyword("family", [this](std::istream& theStream) {
 		character->family = std::pair(commonItems::getULlong(theStream), nullptr);
-		});
+	});
 	registerKeyword("dna", [this](std::istream& theStream) {
 		character->dna = commonItems::getString(theStream);
-		});
+	});
 	registerKeyword("mother", [this](std::istream& theStream) {
 		character->mother = std::pair(commonItems::getULlong(theStream), nullptr);
-		});
+	});
 	registerKeyword("father", [this](std::istream& theStream) {
 		character->father = std::pair(commonItems::getULlong(theStream), nullptr);
-		});
+	});
 	registerKeyword("wealth", [this](std::istream& theStream) {
 		character->wealth = commonItems::getDouble(theStream);
-		});
+	});
 	registerKeyword("spouse", [this](std::istream& theStream) {
 		for (const auto spouse : commonItems::getULlongs(theStream))
 			character->spouses.emplace(spouse, nullptr);
-		});
+	});
 	registerKeyword("children", [this](std::istream& theStream) {
 		for (const auto child : commonItems::getULlongs(theStream))
 			character->children.emplace(child, nullptr);
-		});
+	});
 	registerKeyword("attributes", [this](std::istream& theStream) {
 		const CharacterAttributes attributesFromBloc(theStream);
 		character->attributes.martial = attributesFromBloc.getMartial();
 		character->attributes.finesse = attributesFromBloc.getFinesse();
 		character->attributes.charisma = attributesFromBloc.getCharisma();
 		character->attributes.zeal = attributesFromBloc.getZeal();
-		});
+	});
 	registerMatcher(commonItems::catchallRegexMatch, commonItems::ignoreItem);
 }
 
 
-std::unique_ptr<Imperator::Character> Imperator::Character::Factory::getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB)
-{
+std::unique_ptr<Imperator::Character> Imperator::Character::Factory::getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB) {
 	character = std::make_unique<Character>();
 	character->ID = std::stoull(idString);
 	character->genes = genesDB;
 
 	parseStream(theStream);
 
-	if (character->dna && character->dna.value().size() == 552) character->portraitData.emplace(CharacterPortraitData(character->dna.value(), character->genes, character->getAgeSex()));
+	if (character->dna && character->dna.value().size() == 552) {
+		character->portraitData.emplace(CharacterPortraitData(character->dna.value(), character->genes, character->getAgeSex()));
+	}
 
 	return std::move(character);
 }

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h
@@ -9,11 +9,9 @@
 
 
 
-namespace Imperator
-{
+namespace Imperator {
 
-class Character::Factory: commonItems::parser
-{
+class Character::Factory: commonItems::parser {
   public:
 	explicit Factory();
 	std::unique_ptr<Character> getCharacter(std::istream& theStream, const std::string& idString, const std::shared_ptr<GenesDB>& genesDB);

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterName.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterName.cpp
@@ -3,15 +3,16 @@
 #include "ParserHelpers.h"
 #include "CommonRegexes.h"
 
-Imperator::CharacterName::CharacterName(std::istream& theStream)
-{
+
+
+Imperator::CharacterName::CharacterName(std::istream& theStream) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::CharacterName::registerKeys()
-{
+
+void Imperator::CharacterName::registerKeys() {
 	registerKeyword("name", [this](std::istream& theStream) {
 		name = commonItems::getString(theStream);
 	});

--- a/ImperatorToCK3/Source/Imperator/Characters/CharacterName.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/CharacterName.h
@@ -1,11 +1,14 @@
 #ifndef IMPERATOR_CHARACTER_NAME_H
 #define IMPERATOR_CHARACTER_NAME_H
+
+
+
 #include "Parser.h"
 
-namespace Imperator
-{
-class CharacterName: commonItems::parser
-{
+
+
+namespace Imperator {
+class CharacterName: commonItems::parser {
   public:
 	CharacterName() = default;
 	explicit CharacterName(std::istream& theStream);

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
@@ -1,29 +1,30 @@
 #include "Characters.h"
-#include <utility>
 #include "Character.h"
+#include "../Genes/GenesDB.h"
 #include "../Families/Families.h"
 #include "Log.h"
 #include "ParserHelpers.h"
 #include "CommonRegexes.h"
 #include <set>
+#include <utility>
 
 
 
-Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB): genes(genesDB)
-{
+Imperator::Characters::Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB): genes(genesDB) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::Characters::registerKeys()
-{
+
+void Imperator::Characters::registerKeys() {
 	registerMatcher(commonItems::integerMatch, [this](const std::string& charID, std::istream& theStream) {
 		std::shared_ptr<Character> newCharacter = characterFactory.getCharacter(theStream, charID, genes);
 		characters.emplace(newCharacter->getID(), newCharacter);
 	});
 	registerMatcher(commonItems::catchallRegexMatch, commonItems::ignoreItem);
 }
+
 
 void Imperator::Characters::linkFamilies(const Families& theFamilies) {
 	auto counter = 0;
@@ -56,24 +57,19 @@ void Imperator::Characters::linkFamilies(const Families& theFamilies) {
 	Log(LogLevel::Info) << "<> " << counter << " families linked to characters.";
 }
 
-void Imperator::Characters::linkSpouses()
-{
+
+void Imperator::Characters::linkSpouses() {
 	auto counterSpouse = 0;
-	for (const auto& [characterID, character]: characters)
-	{
-		if (!character->getSpouses().empty())
-		{
+	for (const auto& [characterID, character]: characters) {
+		if (!character->getSpouses().empty()) {
 			std::map<unsigned long long, std::shared_ptr<Character>> newSpouses;
-			for (const auto& [spouseID, spouse]: character->getSpouses())
-			{
+			for (const auto& [spouseID, spouse]: character->getSpouses()) {
 				const auto& characterItr = characters.find(spouseID);
-				if (characterItr != characters.end())
-				{
+				if (characterItr != characters.end()) {
 					newSpouses.emplace(characterItr->first, characterItr->second);
 					++counterSpouse;
 				}
-				else
-				{
+				else {
 					Log(LogLevel::Warning) << "Spouse ID: " << spouseID << " has no definition!";
 				}
 			}
@@ -84,38 +80,30 @@ void Imperator::Characters::linkSpouses()
 }
 
 
-void Imperator::Characters::linkMothersAndFathers()
-{
+void Imperator::Characters::linkMothersAndFathers() {
 	auto counterMother = 0;
 	auto counterFather = 0;
-	for (const auto& character: characters)
-	{
-		if (character.second->getMother().first)
-		{
+	for (const auto& character: characters) {
+		if (character.second->getMother().first) {
 			const auto& characterItr = characters.find(character.second->getMother().first);
-			if (characterItr != characters.end())
-			{
+			if (characterItr != characters.end()) {
 				character.second->setMother(std::pair(characterItr->first, characterItr->second));
 				characterItr->second->registerChild(character);
 				++counterMother;
 			}
-			else
-			{
+			else {
 				Log(LogLevel::Warning) << "Mother ID: " << character.second->getMother().first << " has no definition!";
 			}
 		}
 
-		if (character.second->getFather().first)
-		{
+		if (character.second->getFather().first) {
 			const auto& characterItr = characters.find(character.second->getFather().first);
-			if (characterItr != characters.end())
-			{
+			if (characterItr != characters.end()) {
 				character.second->setFather(std::pair(characterItr->first, characterItr->second));
 				characterItr->second->registerChild(character);
 				++counterFather;
 			}
-			else
-			{
+			else {
 				Log(LogLevel::Warning) << "Father ID: " << character.second->getFather().first << " has no definition!";
 			}
 		}
@@ -126,15 +114,14 @@ void Imperator::Characters::linkMothersAndFathers()
 
 
 
-Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, const GenesDB& genesDB): genes(std::make_shared<GenesDB>(genesDB))
-{
+Imperator::CharactersBloc::CharactersBloc(std::istream& theStream, const GenesDB& genesDB): genes(std::make_shared<GenesDB>(genesDB)) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::CharactersBloc::registerKeys()
-{
+
+void Imperator::CharactersBloc::registerKeys() {
 	registerKeyword("character_database", [this](std::istream& theStream) {
 		characters = Characters(theStream, genes);
 	});

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.h
@@ -4,55 +4,52 @@
 
 
 #include "Parser.h"
-#include "../Genes/GenesDB.h"
 #include "CharacterFactory.h"
 
 
 
-namespace Imperator
-{
-	class Families;
-	class Character;
-	class Characters: commonItems::parser
-	{
-	  public:
-		Characters() = default;
-		Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB);
-
-		Characters& operator= (const Characters& obj) { this->characters = obj.characters; return *this; }
-
-		[[nodiscard]] const auto& getCharacters() const { return characters; }
-
-		void linkFamilies(const Families& theFamilies);
-		void linkSpouses();
-		void linkMothersAndFathers();
-
-	  private:
-		void registerKeys();
-
-		Character::Factory characterFactory;
-
-		std::shared_ptr<GenesDB> genes;
-		//std::shared_ptr<date> endDate;
-
-		std::map<unsigned long long, std::shared_ptr<Character>> characters;
-	}; // class Characters
-
-	
-	class CharactersBloc : commonItems::parser
-	{
+namespace Imperator {
+class Families;
+class Character;
+class Characters: commonItems::parser {
 	public:
-		CharactersBloc() = default;
-		explicit CharactersBloc(std::istream& theStream, const GenesDB& genesDB);
+	Characters() = default;
+	Characters(std::istream& theStream, const std::shared_ptr<GenesDB>& genesDB);
 
-		[[nodiscard]] const auto& getCharactersFromBloc() const { return characters; }
+	Characters& operator= (const Characters& obj) { this->characters = obj.characters; return *this; }
+
+	[[nodiscard]] const auto& getCharacters() const { return characters; }
+
+	void linkFamilies(const Families& theFamilies);
+	void linkSpouses();
+	void linkMothersAndFathers();
 
 	private:
-		void registerKeys();
+	void registerKeys();
 
-		std::shared_ptr<GenesDB> genes;
-		Characters characters;
-	}; // class CharactersBloc
+	Character::Factory characterFactory;
+
+	std::shared_ptr<GenesDB> genes;
+	//std::shared_ptr<date> endDate;
+
+	std::map<unsigned long long, std::shared_ptr<Character>> characters;
+}; // class Characters
+
+	
+class CharactersBloc : commonItems::parser {
+public:
+	CharactersBloc() = default;
+	explicit CharactersBloc(std::istream& theStream, const GenesDB& genesDB);
+
+	[[nodiscard]] const auto& getCharactersFromBloc() const { return characters; }
+
+private:
+	void registerKeys();
+
+	std::shared_ptr<GenesDB> genes;
+	Characters characters;
+}; // class CharactersBloc
+
 } // namespace Imperator
 
 #endif // IMPERATOR_CHARACTERS_H

--- a/ImperatorToCK3/Source/Imperator/Characters/PortraitData.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/PortraitData.cpp
@@ -1,8 +1,10 @@
 #include "PortraitData.h"
+#include "../Genes/GenesDB.h"
 #include "Log.h"
 #include "base64.h"
 #include <bitset>
 #include <utility>
+
 
 
 Imperator::CharacterPortraitData::CharacterPortraitData(const std::string& dnaString, const std::shared_ptr<GenesDB>& genesDB, const std::string& ageSexString) : genes(genesDB)

--- a/ImperatorToCK3/Source/Imperator/Characters/PortraitData.h
+++ b/ImperatorToCK3/Source/Imperator/Characters/PortraitData.h
@@ -2,29 +2,26 @@
 #define IMPERATOR_CHARACTER_PORTRAIT_DATA_H
 
 
+
 #include "Parser.h"
-#include "../Genes/GenesDB.h"
 
 
-namespace Imperator
-{
 
-typedef struct CoordinatesStruct
-{
+namespace Imperator {
+
+typedef struct CoordinatesStruct {
 	unsigned int x = 256; // palettes are 512x512
 	unsigned int y = 256;
 } CoordinatesStruct;
 
-typedef struct AccessoryGeneStruct
-{
+typedef struct AccessoryGeneStruct {
 	std::string geneName;
 	std::string geneTemplate;
 	std::string objectName;
 } AccessoryGeneStruct;
 
-
-class CharacterPortraitData: commonItems::parser
-{
+class GenesDB;
+class CharacterPortraitData: commonItems::parser {
 public:
 	CharacterPortraitData() = default;
 	explicit CharacterPortraitData(const std::string& dnaString, const std::shared_ptr<GenesDB>& genesDB, const std::string& ageSexString = "male");

--- a/ImperatorToCK3/Source/Imperator/Countries/Countries.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/Countries.cpp
@@ -6,15 +6,14 @@
 #include "CommonRegexes.h"
 
 
-Imperator::Countries::Countries(std::istream& theStream)
-{
+
+Imperator::Countries::Countries(std::istream& theStream) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::Countries::registerKeys()
-{
+void Imperator::Countries::registerKeys() {
 	registerMatcher(commonItems::integerMatch, [this](const std::string& countryID, std::istream& theStream) {
 		std::shared_ptr<Country> newCountry = countryFactory.getCountry(theStream, commonItems::stringToInteger<unsigned long long>(countryID));
 		countries.emplace(newCountry->getID(), newCountry);
@@ -23,15 +22,13 @@ void Imperator::Countries::registerKeys()
 }
 
 
-Imperator::CountriesBloc::CountriesBloc(std::istream& theStream)
-{
+Imperator::CountriesBloc::CountriesBloc(std::istream& theStream) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::CountriesBloc::registerKeys()
-{
+void Imperator::CountriesBloc::registerKeys() {
 	registerKeyword("country_database", [this](std::istream& theStream) {
 		countries = Countries(theStream);
 	});
@@ -39,26 +36,20 @@ void Imperator::CountriesBloc::registerKeys()
 }
 
 
-void Imperator::Countries::linkFamilies(const Families& theFamilies)
-{
+void Imperator::Countries::linkFamilies(const Families& theFamilies) {
 	auto counter = 0;
 	std::set<unsigned long long> idsWithoutDefinition;
 	const auto& families = theFamilies.getFamilies();
-	for (const auto& [countryID, country] : countries)
-	{
-		if (!country->getFamilies().empty())
-		{
+	for (const auto& [countryID, country] : countries) {
+		if (!country->getFamilies().empty()) {
 			std::map<unsigned long long, std::shared_ptr<Family>> newFamilies;
-			for (const auto& [familyID, family] : country->getFamilies())
-			{
+			for (const auto& [familyID, family] : country->getFamilies()) {
 				const auto& familyItr = families.find(familyID);
-				if (familyItr != families.end())
-				{
+				if (familyItr != families.end()) {
 					newFamilies.insert(std::pair(familyItr->first, familyItr->second));
 					counter++;
 				}
-				else
-				{
+				else {
 					idsWithoutDefinition.insert(familyID);
 				}
 			}
@@ -67,10 +58,8 @@ void Imperator::Countries::linkFamilies(const Families& theFamilies)
 	}
 
 	std::string warningString = "Families without definition:";
-	if (!idsWithoutDefinition.empty())
-	{
-		for (auto id : idsWithoutDefinition)
-		{
+	if (!idsWithoutDefinition.empty()) {
+		for (auto id : idsWithoutDefinition) {
 			warningString += " ";
 			warningString += std::to_string(id);
 			warningString += ",";

--- a/ImperatorToCK3/Source/Imperator/Countries/Countries.h
+++ b/ImperatorToCK3/Source/Imperator/Countries/Countries.h
@@ -2,47 +2,47 @@
 #define IMPERATOR_COUNTRIES_H
 
 
-#include "Parser.h"
+
 #include "CountryFactory.h"
+#include "Parser.h"
 
 
-namespace Imperator
-{
-	class Country;
-	class Families;
-	class Countries: commonItems::parser
-	{
-	  public:
-		Countries() = default;
-		explicit Countries(std::istream& theStream);
-		
-		auto& operator= (const Countries& obj) { this->countries = obj.countries; return *this; }
 
-		[[nodiscard]] const auto& getCountries() const { return countries; }
-
-		void linkFamilies(const Families& theFamilies);
-
-	  private:
-		void registerKeys();
-
-		Country::Factory countryFactory;
-
-		std::map<unsigned long long, std::shared_ptr<Country>> countries;
-	};
-
-	class CountriesBloc : commonItems::parser
-	{
+namespace Imperator {
+class Country;
+class Families;
+class Countries: commonItems::parser {
 	public:
-		CountriesBloc() = default;
-		explicit CountriesBloc(std::istream& theStream);
+	Countries() = default;
+	explicit Countries(std::istream& theStream);
+		
+	auto& operator= (const Countries& obj) { this->countries = obj.countries; return *this; }
 
-		[[nodiscard]] const auto& getCountriesFromBloc() const { return countries; }
+	[[nodiscard]] const auto& getCountries() const { return countries; }
+
+	void linkFamilies(const Families& theFamilies);
 
 	private:
-		void registerKeys();
+	void registerKeys();
 
-		Countries countries;
-	};
+	Country::Factory countryFactory;
+
+	std::map<unsigned long long, std::shared_ptr<Country>> countries;
+};
+
+class CountriesBloc : commonItems::parser {
+public:
+	CountriesBloc() = default;
+	explicit CountriesBloc(std::istream& theStream);
+
+	[[nodiscard]] const auto& getCountriesFromBloc() const { return countries; }
+
+private:
+	void registerKeys();
+
+	Countries countries;
+};
+
 } // namespace Imperator
 
 #endif // IMPERATOR_COUNTRIES_H

--- a/ImperatorToCK3/Source/Imperator/Countries/Country.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/Country.cpp
@@ -1,8 +1,8 @@
 #include "Country.h"
 
 
-Imperator::countryRankEnum Imperator::Country::getCountryRank() const
-{
+
+Imperator::countryRankEnum Imperator::Country::getCountryRank() const {
 	if (provinceCount == 0) return countryRankEnum::migrantHorde;
 	if (provinceCount == 1) return countryRankEnum::cityState;
 	if (provinceCount <= 24) return countryRankEnum::localPower;

--- a/ImperatorToCK3/Source/Imperator/Countries/Country.h
+++ b/ImperatorToCK3/Source/Imperator/Countries/Country.h
@@ -2,84 +2,84 @@
 #define IMPERATOR_COUNTRY_H
 
 
-#include <set>
+
 #include "Parser.h"
 #include "Color.h"
+#include <set>
 
 
-namespace CK3
-{
-	class Title;
+
+namespace CK3 {
+class Title;
 } // namespace CK3
-namespace Imperator
-{
-	typedef struct CurrenciesStruct
-	{
-		double manpower = 0;
-		double gold = 0;
-		double stability = 50;
-		double tyranny = 0;
-		double war_exhaustion = 0;
-		double aggressive_expansion = 0;
-		double political_influence = 0;
-		double military_experience = 0;
-	} CurrenciesStruct;
 
-	enum class countryTypeEnum { rebels, pirates, barbarians, mercenaries, real };
-	enum class countryRankEnum { migrantHorde, cityState, localPower, regionalPower, majorPower, greatPower };
+namespace Imperator {
 
-	class Family;
-	class Province;
-	class Country
-	{
-		public:
-			class Factory;
-			Country() = default;
+typedef struct CurrenciesStruct {
+	double manpower = 0;
+	double gold = 0;
+	double stability = 50;
+	double tyranny = 0;
+	double war_exhaustion = 0;
+	double aggressive_expansion = 0;
+	double political_influence = 0;
+	double military_experience = 0;
+} CurrenciesStruct;
+
+enum class countryTypeEnum { rebels, pirates, barbarians, mercenaries, real };
+enum class countryRankEnum { migrantHorde, cityState, localPower, regionalPower, majorPower, greatPower };
+
+class Family;
+class Province;
+class Country {
+	public:
+		class Factory;
+		Country() = default;
 		
-			[[nodiscard]] const std::string& getTag() const { return tag; }
-			[[nodiscard]] const auto& getName() const { return name; }
-			[[nodiscard]] const auto& getFlag() const { return flag; }
-			[[nodiscard]] const auto& getCountryType() const { return countryType; }
-			[[nodiscard]] const auto& getCapital() const { return capital; }
-			[[nodiscard]] const auto& getGovernment() const { return government; }
-			[[nodiscard]] const auto& getCurrencies() const { return currencies; }
-			[[nodiscard]] const auto& getColor1() const { return color1; }
-			[[nodiscard]] const auto& getColor2() const { return color2; }
-			[[nodiscard]] const auto& getColor3() const { return color3; }
-			[[nodiscard]] const auto& getFamilies() const { return families; }
-			[[nodiscard]] auto getID() const { return ID; }
-			[[nodiscard]] auto getMonarch() const { return monarch; }
+		[[nodiscard]] const std::string& getTag() const { return tag; }
+		[[nodiscard]] const auto& getName() const { return name; }
+		[[nodiscard]] const auto& getFlag() const { return flag; }
+		[[nodiscard]] const auto& getCountryType() const { return countryType; }
+		[[nodiscard]] const auto& getCapital() const { return capital; }
+		[[nodiscard]] const auto& getGovernment() const { return government; }
+		[[nodiscard]] const auto& getCurrencies() const { return currencies; }
+		[[nodiscard]] const auto& getColor1() const { return color1; }
+		[[nodiscard]] const auto& getColor2() const { return color2; }
+		[[nodiscard]] const auto& getColor3() const { return color3; }
+		[[nodiscard]] const auto& getFamilies() const { return families; }
+		[[nodiscard]] auto getID() const { return ID; }
+		[[nodiscard]] auto getMonarch() const { return monarch; }
 
-			[[nodiscard]] countryRankEnum getCountryRank() const;
+		[[nodiscard]] countryRankEnum getCountryRank() const;
 
-			void setFamilies(const std::map<unsigned long long, std::shared_ptr<Family>>& newFamilies) { families = newFamilies; }
+		void setFamilies(const std::map<unsigned long long, std::shared_ptr<Family>>& newFamilies) { families = newFamilies; }
 
-			void registerProvince(const std::shared_ptr<Province>& province) { provinces.insert(province); ++provinceCount; }
-			void setCK3Title(const std::shared_ptr<CK3::Title>& theTitle) { ck3Title = theTitle; }
+		void registerProvince(const std::shared_ptr<Province>& province) { provinces.insert(province); ++provinceCount; }
+		void setCK3Title(const std::shared_ptr<CK3::Title>& theTitle) { ck3Title = theTitle; }
 
-		private:
-			uint64_t ID = 0;
-			std::optional<unsigned long long> monarch; // >=0 are valid
-			std::string tag;
-			std::string name;
-			std::string flag;
-			countryTypeEnum countryType = countryTypeEnum::real;
-			std::optional<unsigned long long> capital;
-			std::optional<std::string> government;
+	private:
+		uint64_t ID = 0;
+		std::optional<unsigned long long> monarch; // >=0 are valid
+		std::string tag;
+		std::string name;
+		std::string flag;
+		countryTypeEnum countryType = countryTypeEnum::real;
+		std::optional<unsigned long long> capital;
+		std::optional<std::string> government;
 	
-			std::optional<commonItems::Color> color1;
-			std::optional<commonItems::Color> color2;
-			std::optional<commonItems::Color> color3;
-			CurrenciesStruct currencies;
+		std::optional<commonItems::Color> color1;
+		std::optional<commonItems::Color> color2;
+		std::optional<commonItems::Color> color3;
+		CurrenciesStruct currencies;
 
-			std::map<unsigned long long, std::shared_ptr<Family>> families;
+		std::map<unsigned long long, std::shared_ptr<Family>> families;
 		
-			std::set<std::shared_ptr<Province>> provinces;
-			unsigned int provinceCount = 0; // used to determine country rank
+		std::set<std::shared_ptr<Province>> provinces;
+		unsigned int provinceCount = 0; // used to determine country rank
 
-		
-			std::shared_ptr<CK3::Title> ck3Title;
-	};
+		std::shared_ptr<CK3::Title> ck3Title;
+};
+
 } // namespace Imperator
 
 #endif // IMPERATOR_COUNTRY_H

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryCurrencies.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryCurrencies.cpp
@@ -2,15 +2,16 @@
 #include "ParserHelpers.h"
 #include "CommonRegexes.h"
 
-Imperator::CountryCurrencies::CountryCurrencies(std::istream& theStream)
-{
+
+
+Imperator::CountryCurrencies::CountryCurrencies(std::istream& theStream) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::CountryCurrencies::registerKeys()
-{
+
+void Imperator::CountryCurrencies::registerKeys() {
 	registerSetter("manpower", manpower);
 	registerSetter("gold", gold);
 	registerSetter("stability", stability);

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryCurrencies.h
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryCurrencies.h
@@ -1,11 +1,15 @@
 #ifndef IMPERATOR_COUNTRY_CURRENCIES_H
 #define IMPERATOR_COUNTRY_CURRENCIES_H
+
+
+
 #include "ConvenientParser.h"
 
-namespace Imperator
-{
-class CountryCurrencies : commonItems::convenientParser
-{
+
+
+namespace Imperator {
+
+class CountryCurrencies : commonItems::convenientParser {
   public:
 	CountryCurrencies() = default;
 	explicit CountryCurrencies(std::istream& theStream);
@@ -31,6 +35,7 @@ class CountryCurrencies : commonItems::convenientParser
 	double political_influence = 0;
 	double military_experience = 0;
 };
+
 } // namespace Imperator
 
 #endif // IMPERATOR_COUNTRY_CURRENCIES_H

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryFactory.cpp
@@ -1,13 +1,13 @@
-#include "Log.h"
-#include "ParserHelpers.h"
-#include "CommonRegexes.h"
 #include "CountryFactory.h"
 #include "CountryCurrencies.h"
 #include "CountryName.h"
+#include "Log.h"
+#include "ParserHelpers.h"
+#include "CommonRegexes.h"
 
 
-Imperator::Country::Factory::Factory()
-{
+
+Imperator::Country::Factory::Factory() {
 	registerKeyword("tag", [this](std::istream& theStream){
 		country->tag = commonItems::getString(theStream);
 	});
@@ -76,8 +76,7 @@ Imperator::Country::Factory::Factory()
 }
 
 
-std::unique_ptr<Imperator::Country> Imperator::Country::Factory::getCountry(std::istream& theStream, const unsigned long long countryID)
-{
+std::unique_ptr<Imperator::Country> Imperator::Country::Factory::getCountry(std::istream& theStream, const unsigned long long countryID) {
 	country = std::make_unique<Country>();
 	country->ID = countryID;
 

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryFactory.h
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryFactory.h
@@ -9,8 +9,7 @@
 
 
 
-namespace Imperator
-{
+namespace Imperator {
 
 class Country::Factory: commonItems::convenientParser
 {

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryName.cpp
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryName.cpp
@@ -3,15 +3,16 @@
 #include "ParserHelpers.h"
 #include "CommonRegexes.h"
 
-Imperator::CountryName::CountryName(std::istream& theStream)
-{
+
+
+Imperator::CountryName::CountryName(std::istream& theStream) {
 	registerKeys();
 	parseStream(theStream);
 	clearRegisteredKeywords();
 }
 
-void Imperator::CountryName::registerKeys()
-{
+
+void Imperator::CountryName::registerKeys() {
 	registerKeyword("name", [this](std::istream& theStream) {
 		name = commonItems::getString(theStream);
 	});

--- a/ImperatorToCK3/Source/Imperator/Countries/CountryName.h
+++ b/ImperatorToCK3/Source/Imperator/Countries/CountryName.h
@@ -1,13 +1,17 @@
 #ifndef IMPERATOR_COUNTRY_NAME_H
 #define IMPERATOR_COUNTRY_NAME_H
+
+
+
 #include "Parser.h"
 
-namespace Imperator
-{
-class CountryName : commonItems::parser
-{
+
+
+namespace Imperator {
+
+class CountryName : commonItems::parser {
   public:
-	  CountryName() = default;
+	CountryName() = default;
 	explicit CountryName(std::istream& theStream);
 
 	[[nodiscard]] const auto& getName() const { return name; }
@@ -17,6 +21,7 @@ class CountryName : commonItems::parser
 
 	std::string name;
 };
+
 } // namespace Imperator
 
 #endif // IMPERATOR_COUNTRY_NAME_H

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharacterTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharacterTests.cpp
@@ -1,13 +1,15 @@
 #include "gtest/gtest.h"
-#include "../ImperatorToCK3/Source/Imperator/Characters/Character.h"
-#include "../ImperatorToCK3/Source/Imperator/Characters/CharacterFactory.h"
-#include "../ImperatorToCK3/Source/Imperator/Families/Family.h"
-#include "../ImperatorToCK3/Source/Imperator/Families/FamilyFactory.h"
-#include "../commonItems/Date.h"
+#include "Imperator/Characters/Character.h"
+#include "Imperator/Characters/CharacterFactory.h"
+#include "Imperator/Families/Family.h"
+#include "Imperator/Families/FamilyFactory.h"
+#include "Imperator/Genes/GenesDB.h"
+#include "Date.h"
 #include <sstream>
 
-TEST(ImperatorWorld_CharacterTests, IDCanBeSet)
-{
+
+
+TEST(ImperatorWorld_CharacterTests, IDCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -19,8 +21,7 @@ TEST(ImperatorWorld_CharacterTests, IDCanBeSet)
 	ASSERT_EQ(42, theCharacter.getID());
 }
 
-TEST(ImperatorWorld_CharacterTests, cultureCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, cultureCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -33,8 +34,7 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeSet)
 	ASSERT_EQ("paradoxian", theCharacter.getCulture());
 }
 
-TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank)
-{
+TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -47,8 +47,7 @@ TEST(ImperatorWorld_CharacterTests, cultureDefaultsToBlank)
 }
 
 
-TEST(ImperatorWorld_CharacterTests, religionCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, religionCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -61,8 +60,7 @@ TEST(ImperatorWorld_CharacterTests, religionCanBeSet)
 	ASSERT_EQ("paradoxian", theCharacter.getReligion());
 }
 
-TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank)
-{
+TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -74,8 +72,7 @@ TEST(ImperatorWorld_CharacterTests, religionDefaultsToBlank)
 	ASSERT_TRUE(theCharacter.getReligion().empty());
 }
 
-TEST(ImperatorWorld_CharacterTests, sexCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, sexCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -87,8 +84,8 @@ TEST(ImperatorWorld_CharacterTests, sexCanBeSet)
 
 	ASSERT_TRUE(theCharacter.isFemale());
 }
-TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale)
-{
+
+TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -100,8 +97,7 @@ TEST(ImperatorWorld_CharacterTests, sexDefaultsToMale)
 	ASSERT_FALSE(theCharacter.isFemale());
 }
 
-TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, traitsCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const std::vector<std::string> traitsVector{ "lustful", "submissive", "greedy" };
 
@@ -116,8 +112,7 @@ TEST(ImperatorWorld_CharacterTests, traitsCanBeSet)
 	ASSERT_EQ(traitsVector, theCharacter.getTraits());
 }
 
-TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty)
-{
+TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -129,8 +124,7 @@ TEST(ImperatorWorld_CharacterTests, traitsDefaultToEmpty)
 	ASSERT_TRUE(theCharacter.getTraits().empty());
 }
 
-TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -143,8 +137,7 @@ TEST(ImperatorWorld_CharacterTests, birthDateCanBeSet)
 	ASSERT_EQ(date("-346.6.28"), theCharacter.getBirthDate());
 }
 
-TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1)
-{
+TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -156,8 +149,7 @@ TEST(ImperatorWorld_CharacterTests, birthDateDefaultsTo1_1_1)
 	ASSERT_EQ(date("1.1.1"), theCharacter.getBirthDate());
 }
 
-TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -170,8 +162,7 @@ TEST(ImperatorWorld_CharacterTests, deathDateCanBeSet)
 	ASSERT_EQ(date("-346.6.28"), theCharacter.getDeathDate());
 }
 
-TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt)
-{
+TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -183,8 +174,7 @@ TEST(ImperatorWorld_CharacterTests, deathDateDefaultsToNullopt)
 	ASSERT_FALSE(theCharacter.getDeathDate());
 }
 
-TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, spousesCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -215,8 +205,7 @@ TEST(ImperatorWorld_CharacterTests, spousesCanBeSet)
 	ASSERT_EQ(420, theCharacter.getSpouses().find(420)->second->getID());
 }
 
-TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty)
-{
+TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -228,8 +217,7 @@ TEST(ImperatorWorld_CharacterTests, spousesDefaultToEmpty)
 	ASSERT_TRUE(theCharacter.getSpouses().empty());
 }
 
-TEST(ImperatorWorld_CharacterTests, childrenCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, childrenCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -244,8 +232,7 @@ TEST(ImperatorWorld_CharacterTests, childrenCanBeSet)
 	ASSERT_EQ(420, theCharacter.getChildren().find(420)->first);
 }
 
-TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty)
-{
+TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -257,8 +244,7 @@ TEST(ImperatorWorld_CharacterTests, childrenDefaultToEmpty)
 	ASSERT_TRUE(theCharacter.getChildren().empty());
 }
 
-TEST(ImperatorWorld_CharacterTests, motherCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, motherCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -271,8 +257,7 @@ TEST(ImperatorWorld_CharacterTests, motherCanBeSet)
 	ASSERT_EQ(123, theCharacter.getMother().first);
 }
 
-TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero)
-{
+TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -284,8 +269,7 @@ TEST(ImperatorWorld_CharacterTests, motherDefaultsToZero)
 	ASSERT_EQ(0, theCharacter.getMother().first);
 }
 
-TEST(ImperatorWorld_CharacterTests, fatherCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, fatherCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -298,8 +282,7 @@ TEST(ImperatorWorld_CharacterTests, fatherCanBeSet)
 	ASSERT_EQ(123, theCharacter.getFather().first);
 }
 
-TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero)
-{
+TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -311,8 +294,7 @@ TEST(ImperatorWorld_CharacterTests, fatherDefaultsToZero)
 	ASSERT_EQ(0, theCharacter.getFather().first);
 }
 
-TEST(ImperatorWorld_CharacterTests, familyCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, familyCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -325,8 +307,7 @@ TEST(ImperatorWorld_CharacterTests, familyCanBeSet)
 	ASSERT_EQ(123, theCharacter.getFamily().first);
 }
 
-TEST(ImperatorWorld_CharacterTests, familyDefaultsToZero)
-{
+TEST(ImperatorWorld_CharacterTests, familyDefaultsToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -337,8 +318,8 @@ TEST(ImperatorWorld_CharacterTests, familyDefaultsToZero)
 
 	ASSERT_EQ(0, theCharacter.getFamily().first);
 }
-TEST(ImperatorWorld_CharacterTests, wealthCanBeSet)
-{
+
+TEST(ImperatorWorld_CharacterTests, wealthCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -351,8 +332,7 @@ TEST(ImperatorWorld_CharacterTests, wealthCanBeSet)
 	ASSERT_DOUBLE_EQ(420.5, theCharacter.getWealth());
 }
 
-TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero)
-{
+TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -364,8 +344,7 @@ TEST(ImperatorWorld_CharacterTests, wealthDefaultsToZero)
 	ASSERT_EQ(0, theCharacter.getWealth());
 }
 
-TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, nameCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -380,8 +359,7 @@ TEST(ImperatorWorld_CharacterTests, nameCanBeSet)
 	ASSERT_EQ("Biggus Dickus", theCharacter.getName());
 }
 
-TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank)
-{
+TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -393,8 +371,7 @@ TEST(ImperatorWorld_CharacterTests, nameDefaultsToBlank)
 	ASSERT_TRUE(theCharacter.getName().empty());
 }
 
-TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero)
-{
+TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -409,8 +386,7 @@ TEST(ImperatorWorld_CharacterTests, attributesDefaultToZero)
 	ASSERT_EQ(0, theCharacter.getAttributes().zeal);
 }
 
-TEST(ImperatorWorld_CharacterTests, attributesCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, attributesCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -426,8 +402,7 @@ TEST(ImperatorWorld_CharacterTests, attributesCanBeSet)
 	ASSERT_EQ(4, theCharacter.getAttributes().zeal);
 }
 
-TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
-{
+TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream familyInput;
 	familyInput << "=\n";
@@ -445,8 +420,7 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 
 	auto theCharacter = *Imperator::Character::Factory().getCharacter(characterInput, "69", genesDB);
 
-	if (theCharacter.getFamily().first == theFamily.getID())
-	{
+	if (theCharacter.getFamily().first == theFamily.getID()) {
 		auto familyPointer = std::make_shared<Imperator::Family>(theFamily);
 		theCharacter.setFamily(familyPointer);
 	}
@@ -455,8 +429,7 @@ TEST(ImperatorWorld_CharacterTests, cultureCanBeInheritedFromFamily)
 }
 
 
-TEST(ImperatorWorld_CharacterTests, dnaCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, dnaCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -469,8 +442,7 @@ TEST(ImperatorWorld_CharacterTests, dnaCanBeSet)
 	ASSERT_EQ("paradoxian", theCharacter.getDNA());
 }
 
-TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt)
-{
+TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -483,8 +455,7 @@ TEST(ImperatorWorld_CharacterTests, dnaDefaultsToNullopt)
 }
 
 
-TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLength)
-{
+TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLength) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "={dna=\"AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/==\"}";
@@ -494,8 +465,7 @@ TEST(ImperatorWorld_CharacterTests, portraitDataIsNotExtractedFromDnaOfWrongLeng
 }
 
 
-TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA)
-{
+TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "={dna=\"AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\"}";
@@ -510,8 +480,7 @@ TEST(ImperatorWorld_CharacterTests, colorPaletteCoordinatesCanBeExtractedFromDNA
 }
 
 
-TEST(ImperatorWorld_CharacterTests, ageCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, ageCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -523,8 +492,8 @@ TEST(ImperatorWorld_CharacterTests, ageCanBeSet)
 
 	ASSERT_EQ(56, theCharacter.getAge());
 }
-TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0)
-{
+
+TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -537,8 +506,7 @@ TEST(ImperatorWorld_CharacterTests, ageDefaultsTo0)
 }
 
 
-TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
-{
+TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input, input2, input3, input4;
 	input << "=\n";
@@ -574,8 +542,7 @@ TEST(ImperatorWorld_CharacterTests, getAgeSexReturnsCorrectString)
 	ASSERT_EQ("boy", theCharacter4.getAgeSex());
 }
 
-TEST(ImperatorWorld_CharacterTests, provinceCanBeSet)
-{
+TEST(ImperatorWorld_CharacterTests, provinceCanBeSet) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -588,8 +555,7 @@ TEST(ImperatorWorld_CharacterTests, provinceCanBeSet)
 	ASSERT_EQ(69, theCharacter.getProvince());
 }
 
-TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0)
-{
+TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "=\n";
@@ -601,8 +567,7 @@ TEST(ImperatorWorld_CharacterTests, provinceDefaultsTo0)
 	ASSERT_EQ(0, theCharacter.getProvince());
 }
 
-TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC)
-{
+TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "= { birth_date = 0.1.1 }";
@@ -612,8 +577,7 @@ TEST(ImperatorWorld_CharacterTests, AUC0ConvertsTo754BC)
 	ASSERT_EQ("-754.1.1", theCharacter.getBirthDate().toString());
 }
 
-TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC)
-{
+TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "= { birth_date = 753.1.1 }";
@@ -623,8 +587,7 @@ TEST(ImperatorWorld_CharacterTests, AUC753ConvertsTo1BC)
 	ASSERT_EQ("-1.1.1", theCharacter.getBirthDate().toString());
 }
 
-TEST(ImperatorWorld_CharacterTests, AUC754ConvertsTo1AD)
-{
+TEST(ImperatorWorld_CharacterTests, AUC754ConvertsTo1AD) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	std::stringstream input;
 	input << "= { birth_date = 754.1.1 }";
@@ -633,4 +596,3 @@ TEST(ImperatorWorld_CharacterTests, AUC754ConvertsTo1AD)
 
 	ASSERT_EQ("1.1.1", theCharacter.getBirthDate().toString());
 }
-

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharactersTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/CharactersTests.cpp
@@ -1,11 +1,12 @@
 #include "gtest/gtest.h"
 #include <sstream>
+#include "Imperator/Characters/Characters.h"
+#include "Imperator/Characters/Character.h"
+#include "Imperator/Genes/GenesDB.h"
 
-#include "../ImperatorToCK3/Source/Imperator/Characters/Characters.h"
-#include "../ImperatorToCK3/Source/Imperator/Characters/Character.h"
 
-TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty)
-{
+
+TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty) {
 	const auto genes = std::make_shared<Imperator::GenesDB>();
 	
 	std::stringstream input;
@@ -18,8 +19,7 @@ TEST(ImperatorWorld_CharactersTests, charactersDefaultToEmpty)
 	ASSERT_TRUE(characters.getCharacters().empty());
 }
 
-TEST(ImperatorWorld_CharactersTests, charactersCanBeLoaded)
-{
+TEST(ImperatorWorld_CharactersTests, charactersCanBeLoaded) {
 	const auto genes = std::make_shared<Imperator::GenesDB>();
 	
 	std::stringstream input;

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Characters/PortraitDataTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Characters/PortraitDataTests.cpp
@@ -1,10 +1,10 @@
 #include "gtest/gtest.h"
-#include "../ImperatorToCK3/Source/Imperator/Characters/PortraitData.h"
+#include "Imperator/Characters/PortraitData.h"
+#include "Imperator/Genes/GenesDB.h"
 
 
 
-TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToZero)
-{
+TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -12,8 +12,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToZero)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToMax)
-{
+TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToMax) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "/wAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -21,8 +20,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToMax)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToArbitraryValue)
-{
+TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToArbitraryValue) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "ZAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -30,8 +28,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorXCanBeSetToArbitraryValue)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToZero)
-{
+TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -39,8 +36,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToZero)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToMax)
-{
+TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToMax) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AP8AAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -48,8 +44,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToMax)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToArbitraryValue)
-{
+TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToArbitraryValue) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AGQAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -57,8 +52,7 @@ TEST(ImperatorWorld_PortraitDataTests, HairColorYCanBeSetToArbitraryValue)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToZero)
-{
+TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -66,8 +60,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToZero)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToMax)
-{
+TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToMax) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAP8AAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -75,8 +68,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToMax)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToArbitraryValue)
-{
+TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToArbitraryValue) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAGQAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -84,8 +76,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorXCanBeSetToArbitraryValue)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToZero)
-{
+TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -93,8 +84,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToZero)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToMax)
-{
+TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToMax) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAD/AAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -102,8 +92,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToMax)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToArbitraryValue)
-{
+TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToArbitraryValue) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAABkAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -111,8 +100,7 @@ TEST(ImperatorWorld_PortraitDataTests, SkinColorYCanBeSetToArbitraryValue)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToZero)
-{
+TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -120,8 +108,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToZero)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToMax)
-{
+TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToMax) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAD/AAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -129,8 +116,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToMax)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToArbitraryValue)
-{
+TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToArbitraryValue) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAABkAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -138,8 +124,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorXCanBeSetToArbitraryValue)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToZero)
-{
+TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToZero) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAAAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -147,8 +132,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToZero)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToMax)
-{
+TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToMax) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAA/wAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 
@@ -156,8 +140,7 @@ TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToMax)
 }
 
 
-TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToArbitraryValue)
-{
+TEST(ImperatorWorld_PortraitDataTests, EyeColorYCanBeSetToArbitraryValue) {
 	const auto genesDB = std::make_shared<Imperator::GenesDB>();
 	const Imperator::CharacterPortraitData testPortraitData{ "AAAAAAAAAAAAZAAAAH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AfwB/AH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", genesDB };
 


### PR DESCRIPTION
- Used forward declarations in header files instead of includes wherever possible (AppVeyor build are getting too long).
- Applied my preferred format of opening curly braces (on the same line).
- No functionality changes.