### PR TITLE
Tweaks

### DIFF
--- a/ImperatorToCK3/ImperatorToCK3.vcxproj
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj
@@ -272,6 +272,7 @@
     <ClCompile Include="Source\Imperator\ImperatorWorld.cpp" />
     <ClCompile Include="Source\Imperator\Provinces\PopFactory.cpp" />
     <ClCompile Include="Source\Imperator\Provinces\Pops.cpp" />
+    <ClCompile Include="Source\Imperator\Provinces\Province.cpp" />
     <ClCompile Include="Source\Imperator\Provinces\ProvinceFactory.cpp" />
     <ClCompile Include="Source\Imperator\Provinces\ProvinceName.cpp" />
     <ClCompile Include="Source\Imperator\Provinces\Provinces.cpp" />

--- a/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
+++ b/ImperatorToCK3/ImperatorToCK3.vcxproj.filters
@@ -653,12 +653,17 @@
     <ClCompile Include="Source\CK3\Dynasties\Dynasty.cpp">
       <Filter>CK3\Dynasties</Filter>
     </ClCompile>
-    <ClCompile Include="Source\Imperator\Families\Family.cpp" />
     <ClCompile Include="Source\CK3Outputter\outDynasties.cpp">
       <Filter>CK3Outputter</Filter>
     </ClCompile>
     <ClCompile Include="Source\CK3Outputter\outDynasty.cpp">
       <Filter>CK3Outputter</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Imperator\Families\Family.cpp">
+      <Filter>Imperator\Families</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Imperator\Provinces\Province.cpp">
+      <Filter>Imperator\Provinces</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -204,12 +204,12 @@ std::optional<std::pair<unsigned long long, std::shared_ptr<Imperator::Province>
 	for (auto imperatorProvinceID : impProvinceNumbers) {
 		const auto& impProvince = impWorld.getProvinces().find(imperatorProvinceID);
 		if (impProvince == impWorld.getProvinces().end()) {
-			Log(LogLevel::Warning) << "Source province " << imperatorProvinceID << " is not in the list of known provinces!";
+			Log(LogLevel::Warning) << "Source province " << imperatorProvinceID << " is not on the list of known provinces!";
 			continue; // Broken mapping, or loaded a mod changing provinces without using it.
 		}
-		const auto owner = impProvince->second->getOwner();
-		theClaims[owner].push_back(impProvince->second);
-		theShares[owner] = lround(impProvince->second->getBuildingsCount() + impProvince->second->getPopCount());
+		const auto ownerID = impProvince->second->getOwner().first;
+		theClaims[ownerID].emplace_back(impProvince->second);
+		theShares[ownerID] = lround(impProvince->second->getBuildingsCount() + impProvince->second->getPopCount());
 	}
 	// Let's see who the lucky winner is.
 	for (const auto& [owner, development] : theShares) {
@@ -251,8 +251,9 @@ void CK3::World::addHoldersAndHistoryToTitles(const Imperator::World& impWorld) 
 				auto& impProvince = provinces.find(title->capitalBaronyProvince)->second->getImperatorProvince();
 				if (impProvince) {
 					std::optional<unsigned long long> impMonarch;
-					if (auto countryItr = impWorld.getCountries().find(impProvince->getOwner()); countryItr != impWorld.getCountries().end())
-						impMonarch = countryItr->second->getMonarch();
+					if (auto impCountry = impProvince->getOwner().second) {
+						impMonarch = impCountry->getMonarch();
+					}
 					if (impMonarch) {
 						title->holder = "imperator" + std::to_string(*impMonarch);
 						countyHoldersCache.emplace(title->holder);

--- a/ImperatorToCK3/Source/CK3/CK3World.cpp
+++ b/ImperatorToCK3/Source/CK3/CK3World.cpp
@@ -300,7 +300,7 @@ void CK3::World::removeInvalidLandlessTitles() {
 			msg += ", ";
 		}
 		msg.erase(msg.length() - 2); // remove last ", "
-		Log(LogLevel::Info) << msg;
+		Log(LogLevel::Debug) << msg;
 	}
 	if (!revokedVanillaTitles.empty()) {
 		std::string msg = "Found landless vanilla titles that can't be landless: ";
@@ -309,7 +309,7 @@ void CK3::World::removeInvalidLandlessTitles() {
 			msg += ", ";
 		}
 		msg.erase(msg.length() - 2); // remove last ", "
-		Log(LogLevel::Info) << msg;
+		Log(LogLevel::Debug) << msg;
 	}
 }
 

--- a/ImperatorToCK3/Source/CK3/Province/CK3Province.h
+++ b/ImperatorToCK3/Source/CK3/Province/CK3Province.h
@@ -45,13 +45,13 @@ class Province {
 	friend std::ostream& operator<<(std::ostream& output, const Province& province);
 
   private:
-	  void setReligion(const mappers::ReligionMapper& religionMapper);
-	  void setCulture(const mappers::CultureMapper& cultureMapper);
-	  void setHolding();
+	  void setReligionFromImperator(const mappers::ReligionMapper& religionMapper);
+	  void setCultureFromImperator(const mappers::CultureMapper& cultureMapper);
+	  void setHoldingFromImperator();
 	
 	  unsigned long long ID = 0;
 	  ProvinceDetails details;
-	  std::pair<std::string, std::shared_ptr<Title>> titleCountry;
+	  std::shared_ptr<Title> ownerTitle;
 
 	  std::shared_ptr<Imperator::Province> imperatorProvince;
 };

--- a/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
+++ b/ImperatorToCK3/Source/CK3/Province/ProvinceDetails.cpp
@@ -11,6 +11,7 @@ History::Factory CK3::ProvinceDetails::historyFactory = History::Factory({
 	{ .fieldName="holding", .setter="holding", .initialValue="none" }
 });
 
+
 CK3::ProvinceDetails::ProvinceDetails(std::istream& theStream) {
 	const auto history = historyFactory.getHistory(theStream);
 	const date date{867, 1, 1};

--- a/ImperatorToCK3/Source/Imperator/Countries/Country.h
+++ b/ImperatorToCK3/Source/Imperator/Countries/Country.h
@@ -35,7 +35,9 @@ class Country {
 	public:
 		class Factory;
 		Country() = default;
-		
+
+		[[nodiscard]] auto getID() const { return ID; }
+		[[nodiscard]] auto getMonarch() const { return monarch; }
 		[[nodiscard]] const std::string& getTag() const { return tag; }
 		[[nodiscard]] const auto& getName() const { return name; }
 		[[nodiscard]] const auto& getFlag() const { return flag; }
@@ -47,8 +49,7 @@ class Country {
 		[[nodiscard]] const auto& getColor2() const { return color2; }
 		[[nodiscard]] const auto& getColor3() const { return color3; }
 		[[nodiscard]] const auto& getFamilies() const { return families; }
-		[[nodiscard]] auto getID() const { return ID; }
-		[[nodiscard]] auto getMonarch() const { return monarch; }
+		[[nodiscard]] const auto& getCK3Title() const { return ck3Title; }
 
 		[[nodiscard]] countryRankEnum getCountryRank() const;
 
@@ -81,5 +82,7 @@ class Country {
 };
 
 } // namespace Imperator
+
+
 
 #endif // IMPERATOR_COUNTRY_H

--- a/ImperatorToCK3/Source/Imperator/Families/Family.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.cpp
@@ -15,6 +15,10 @@ void Imperator::Family::linkMember(const std::shared_ptr<Character>& newMemberPt
 			return;
 		}
 	}
+	if (newMemberPtr->getDeathDate()) { // if character is dead, his ID needs to be added to the map
+		members.emplace_back(newMemberPtr->getID(), newMemberPtr);
+		return;
+	}
 	// matching ID was not found
 	Log(LogLevel::Warning) << "Family " << ID << ": cannot link " << newMemberPtr->getID() << ": not found in members!";
 }

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.cpp
@@ -1,0 +1,17 @@
+#include "Province.h"
+#include "Imperator/Countries/Country.h"
+#include "Log.h"
+
+
+
+void Imperator::Province::linkOwnerCountry(const std::shared_ptr<Country>& country) {
+	if (!country) {
+		Log(LogLevel::Warning) << "Province " << ID << ": cannot link nullptr country!";
+		return;
+	}
+	if (country->getID() != ownerCountry.first)
+		Log(LogLevel::Warning) << "Province " << ID << ": cannot link country " << country->getID() << ": wrong ID!";
+	else {
+		ownerCountry.second = country;
+	}
+}

--- a/ImperatorToCK3/Source/Imperator/Provinces/Province.h
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Province.h
@@ -24,7 +24,7 @@ public:
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getCulture() const { return culture; }
 	[[nodiscard]] const auto& getReligion() const { return religion; }
-	[[nodiscard]] const auto& getOwner() const { return owner; }
+	[[nodiscard]] const auto& getOwner() const { return ownerCountry; }
 	[[nodiscard]] const auto& getController() const { return controller; }
 	[[nodiscard]] const auto& getPops() const { return pops; }
 	[[nodiscard]] const auto& getProvinceRank() const {	return provinceRank; }
@@ -35,15 +35,14 @@ public:
 	[[nodiscard]] auto getPopCount() const { return static_cast<int>(pops.size()); }
 
 	void setPops(const std::map<unsigned long long, std::shared_ptr<Pop>>& newPops) { pops = newPops; }
-
-	std::shared_ptr<Country> country;
+	void linkOwnerCountry(const std::shared_ptr<Country>& country);
 
 private:
 	uint64_t ID = 0;
 	std::string name;
 	std::string culture;
 	std::string religion;
-	unsigned long long owner = 0;
+	std::pair<unsigned long long, std::shared_ptr<Country>> ownerCountry{ 0, nullptr };
 	unsigned long long controller = 0;
 	ProvinceRank provinceRank = ProvinceRank::settlement;
 	bool fort = false;

--- a/ImperatorToCK3/Source/Imperator/Provinces/ProvinceFactory.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/ProvinceFactory.cpp
@@ -17,7 +17,7 @@ Imperator::Province::Factory::Factory() {
 		province->religion = commonItems::getString(theStream);	
 	});	
 	registerKeyword("owner", [this](std::istream& theStream) {	
-		province->owner = commonItems::getULlong(theStream);	
+		province->ownerCountry.first = commonItems::getULlong(theStream);	
 	});	
 	registerKeyword("controller", [this](std::istream& theStream) {	
 		province->controller = commonItems::getULlong(theStream);	

--- a/ImperatorToCK3/Source/Imperator/Provinces/Provinces.cpp
+++ b/ImperatorToCK3/Source/Imperator/Provinces/Provinces.cpp
@@ -53,15 +53,15 @@ void Imperator::Provinces::linkCountries(const Countries& theCountries) {
 	const auto& countries = theCountries.getCountries();
 	for (const auto& [provinceID, province] : provinces) {
 		if (!province->getPops().empty()) {
-			const auto& countryItr = countries.find(province->getOwner());
+			const auto& countryItr = countries.find(province->getOwner().first);
 			if (countryItr != countries.end()) {
 				// link both ways
-				province->country = countryItr->second;
+				province->linkOwnerCountry(countryItr->second);
 				countryItr->second->registerProvince(province);
 				++counter;
 			}
 			else {
-				Log(LogLevel::Warning) << "Country ID: " << province->getOwner() << " has no definition!";
+				Log(LogLevel::Warning) << "Country ID: " << province->getOwner().first << " has no definition!";
 			}
 		}
 	}

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj
@@ -215,6 +215,7 @@
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Genes\WeightBlock.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\PopFactory.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\Pops.cpp" />
+    <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\Province.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\ProvinceFactory.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\ProvinceName.cpp" />
     <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\Provinces.cpp" />

--- a/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
+++ b/ImperatorToCK3Tests/ImperatorToCK3Tests.vcxproj.filters
@@ -477,6 +477,9 @@
     <ClCompile Include="..\ImperatorToCK3\Source\CK3\Dynasties\Dynasty.cpp">
       <Filter>Sources\CK3\Dynasties</Filter>
     </ClCompile>
+    <ClCompile Include="..\ImperatorToCK3\Source\Imperator\Provinces\Province.cpp">
+      <Filter>Sources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ImperatorToCK3\Source\Imperator\Provinces\Province.h">

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Provinces/ProvinceTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Provinces/ProvinceTests.cpp
@@ -102,7 +102,7 @@ TEST(ImperatorWorld_ProvinceTests, ownerCanBeSet)
 
 	const auto theProvince = *Imperator::Province::Factory().getProvince(input, 42);
 
-	ASSERT_EQ(69, theProvince.getOwner());
+	ASSERT_EQ(69, theProvince.getOwner().first);
 }
 
 TEST(ImperatorWorld_ProvinceTests, ownerDefaultsTo0)
@@ -114,7 +114,7 @@ TEST(ImperatorWorld_ProvinceTests, ownerDefaultsTo0)
 
 	const auto theProvince = *Imperator::Province::Factory().getProvince(input, 42);
 
-	ASSERT_EQ(0, theProvince.getOwner());
+	ASSERT_EQ(0, theProvince.getOwner().first);
 }
 
 TEST(ImperatorWorld_ProvinceTests, controllerCanBeSet)

--- a/ImperatorToCK3Tests/ImperatorWorldTests/Provinces/ProvinceTests.cpp
+++ b/ImperatorToCK3Tests/ImperatorWorldTests/Provinces/ProvinceTests.cpp
@@ -1,7 +1,10 @@
 #include "gtest/gtest.h"
 #include "Imperator/Provinces/Province.h"
 #include "Imperator/Provinces/ProvinceFactory.h"
+#include "Imperator/Countries/CountryFactory.h"
 #include <sstream>
+
+
 
 TEST(ImperatorWorld_ProvinceTests, IDCanBeSet)
 {
@@ -229,4 +232,61 @@ TEST(ImperatorWorld_ProvinceTests, buildingsCountDefaultsTo0)
 	const auto theProvince = *Imperator::Province::Factory().getProvince(input, 42);
 
 	ASSERT_EQ(0, theProvince.getBuildingsCount());
+}
+
+
+TEST(ImperatorWorld_ProvinceTests, linkingNullptrCountryIsLogged) {
+	std::stringstream input;
+	input << "= {}";
+	auto province = *Imperator::Province::Factory().getProvince(input, 42);
+
+	std::stringstream log;
+	auto* stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	province.linkOwnerCountry(nullptr);
+
+	std::cout.rdbuf(stdOutBuf);
+	auto stringLog = log.str();
+	auto newLine = stringLog.find_first_of('\n');
+	stringLog = stringLog.substr(0, newLine);
+
+	ASSERT_EQ(" [WARNING] Province 42: cannot link nullptr country!", stringLog);
+}
+
+
+TEST(ImperatorWorld_ProvinceTests, cannotLinkCountryWithoutMatchingID) {
+	std::stringstream input;
+	input << "= { owner = 50 }";
+	auto province = *Imperator::Province::Factory().getProvince(input, 42);
+
+	std::stringstream countryInput;
+	std::shared_ptr<Imperator::Country> country = Imperator::Country::Factory().getCountry(countryInput, 49);
+
+	std::stringstream log;
+	auto* stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	province.linkOwnerCountry(country);
+
+	std::cout.rdbuf(stdOutBuf);
+	auto stringLog = log.str();
+	auto newLine = stringLog.find_first_of('\n');
+	stringLog = stringLog.substr(0, newLine);
+
+	ASSERT_EQ(" [WARNING] Province 42: cannot link country 49: wrong ID!", stringLog);
+}
+
+
+TEST(ImperatorWorld_ProvinceTests, countryLinkingWorks) {
+	std::stringstream input;
+	input << "= { owner = 50 }";
+	auto province = *Imperator::Province::Factory().getProvince(input, 42);
+
+	std::stringstream countryInput;
+	std::shared_ptr<Imperator::Country> country = Imperator::Country::Factory().getCountry(countryInput, 50);
+
+	province.linkOwnerCountry(country);
+
+	ASSERT_EQ(50, province.getOwner().second->getID());
 }


### PR DESCRIPTION
- Fix for dead Imperator characters not being linked to families
- Lowered the log level of "Found landless" titles messages
- Tweaked province culture conversion for cases where a culture mapping has an `owner` entry