### PR TITLE
Fix for Imperator::Character::getCulture() causing crashes

### DIFF
--- a/ImperatorToCK3/Source/CK3/Character/CK3Character.cpp
+++ b/ImperatorToCK3/Source/CK3/Character/CK3Character.cpp
@@ -37,10 +37,11 @@ void CK3::Character::initializeFromImperator(std::shared_ptr<Imperator::Characte
 	if (provinceMapper.getCK3ProvinceNumbers(impProvForProvinceMapper).empty() && !imperatorCharacter->getSpouses().empty())
 		impProvForProvinceMapper = imperatorCharacter->getSpouses().begin()->second->getProvince();
 
-	if (provinceMapper.getCK3ProvinceNumbers(impProvForProvinceMapper).empty())
+	auto ck3ProvinceNumbers = provinceMapper.getCK3ProvinceNumbers(impProvForProvinceMapper);
+	if (ck3ProvinceNumbers.empty())
 		ck3Province = 0;
 	else
-		ck3Province = provinceMapper.getCK3ProvinceNumbers(impProvForProvinceMapper)[0];
+		ck3Province = ck3ProvinceNumbers[0];
 
 	auto match = religionMapper.match(imperatorCharacter->getReligion(), ck3Province, imperatorCharacter->getProvince());
 	if (match)

--- a/ImperatorToCK3/Source/Imperator/Characters/Character.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Character.cpp
@@ -7,7 +7,7 @@
 const std::string& Imperator::Character::getCulture() const {
 	if (!culture.empty())
 		return culture;
-	if (family.first && !family.second->getCulture().empty())
+	if (family.first && family.second && !family.second->getCulture().empty())
 		return family.second->getCulture();
 	return culture;
 }

--- a/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
+++ b/ImperatorToCK3/Source/Imperator/Characters/Characters.cpp
@@ -52,15 +52,15 @@ void Imperator::Characters::linkFamilies(const Families& theFamilies) {
 		}
 	}
 
-	std::string warningString = "Families without definition:";
+	std::string logString = "Families without definition:";
 	if (!idsWithoutDefinition.empty()) {
 		for (auto id : idsWithoutDefinition) {
-			warningString += " ";
-			warningString += std::to_string(id);
-			warningString += ",";
+			logString += " ";
+			logString += std::to_string(id);
+			logString += ",";
 		}
-		warningString = warningString.substr(0, warningString.size() - 1); //remove last comma
-		Log(LogLevel::Warning) << warningString;
+		logString = logString.substr(0, logString.size() - 1);	// remove last comma
+		Log(LogLevel::Info) << logString;
 	}
 	
 	Log(LogLevel::Info) << "<> " << counter << " families linked to characters.";


### PR DESCRIPTION
If a character's family has no definition, character's `family.first` has correct ID, but `family.second` remains nullptr. I added a check for that in `getCulture()`.