### PR TITLE
Fix for unlinked family members crashing conversion

### DIFF
--- a/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
+++ b/ImperatorToCK3/Source/CK3/Dynasties/Dynasty.cpp
@@ -12,7 +12,8 @@ CK3::Dynasty::Dynasty(const Imperator::Family& impFamily, const mappers::Localiz
 
 	const auto& impMembers = impFamily.getMembers();
 	if (!impMembers.empty()) {
-		culture = impMembers[0].second->getCK3Character()->culture; // make head's culture the dynasty culture
+		auto firstMember = impMembers[0];
+		culture = firstMember.second->getCK3Character()->culture;  // make head's culture the dynasty culture
 	}
 	else {
 		Log(LogLevel::Warning) << "Couldn't determine culture for dynasty " << ID << ", needs manual setting!";

--- a/ImperatorToCK3/Source/Imperator/Families/Families.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Families.cpp
@@ -19,6 +19,13 @@ void Imperator::Families::loadFamilies(std::istream& theStream) {
 }
 
 
+void Imperator::Families::removeUnlinkedMembers() {
+	for (const auto& family : families) {
+		family.second->removeUnlinkedMembers();
+	}
+}
+
+
 void Imperator::Families::registerKeys() {
 	registerRegex(commonItems::integerRegex, [this](const std::string& theFamilyID, std::istream& theStream) {
 		const auto familyStr = commonItems::stringOfItem(theStream).getString();

--- a/ImperatorToCK3/Source/Imperator/Families/Families.h
+++ b/ImperatorToCK3/Source/Imperator/Families/Families.h
@@ -15,6 +15,7 @@ class Families : commonItems::parser {
 public:
 	void loadFamilies(const std::string& thePath);
 	void loadFamilies(std::istream& theStream);
+	void removeUnlinkedMembers();
 
 	auto& operator= (const Families& obj) { this->families = obj.families; return *this; }
 

--- a/ImperatorToCK3/Source/Imperator/Families/Family.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.cpp
@@ -25,5 +25,5 @@ void Imperator::Family::linkMember(const std::shared_ptr<Character>& newMemberPt
 
 
 void Imperator::Family::removeUnlinkedMembers() {
-	auto removedCount = std::erase_if(members, [](auto member) { return member.second == nullptr; });
+	std::erase_if(members, [](auto member) { return member.second == nullptr; });
 }

--- a/ImperatorToCK3/Source/Imperator/Families/Family.cpp
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.cpp
@@ -22,3 +22,8 @@ void Imperator::Family::linkMember(const std::shared_ptr<Character>& newMemberPt
 	// matching ID was not found
 	Log(LogLevel::Warning) << "Family " << ID << ": cannot link " << newMemberPtr->getID() << ": not found in members!";
 }
+
+
+void Imperator::Family::removeUnlinkedMembers() {
+	auto removedCount = std::erase_if(members, [](auto member) { return member.second == nullptr; });
+}

--- a/ImperatorToCK3/Source/Imperator/Families/Family.h
+++ b/ImperatorToCK3/Source/Imperator/Families/Family.h
@@ -17,6 +17,7 @@ class Family {
 	Family() = default;
 
 	void linkMember(const std::shared_ptr<Character>& newMemberPtr);
+	void removeUnlinkedMembers();
 
 	[[nodiscard]] auto getID() const { return ID; }
 	[[nodiscard]] const auto& getKey() const { return key; }

--- a/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
+++ b/ImperatorToCK3/Source/Imperator/ImperatorWorld.cpp
@@ -104,6 +104,7 @@ Imperator::World::World(const Configuration& theConfiguration, const commonItems
 	// Link all the intertwining pointers
 	Log(LogLevel::Info) << "-- Linking Characters with Families";
 	characters.linkFamilies(families);
+	families.removeUnlinkedMembers();
 	Log(LogLevel::Info) << "-- Linking Characters with Spouses";
 	characters.linkSpouses();
 	Log(LogLevel::Info) << "-- Linking Characters with Mothers and Fathers";


### PR DESCRIPTION
The converter didn't handle edge cases like characters changing family.