### PR TITLE
Better encapsulation for Imperator Characters class

### DIFF
--- a/ImperatorToCK3.UnitTests/Imperator/Characters/CharacterTests.cs
+++ b/ImperatorToCK3.UnitTests/Imperator/Characters/CharacterTests.cs
@@ -19,7 +19,7 @@ namespace ImperatorToCK3.UnitTests.Imperator.Characters {
 				"\tbirth_date=408.6.28" + // will be converted to AD date on loading
 				"\tdeath_date=408.6.28" + // will be converted to AD date on loading
 				"\tdeath = killed_in_battle" +
-				"\tspouse= { 69 420 } " +
+				"\tspouse= { 3 4 } " +
 				"\tchildren = { 69 420 } " +
 				"\tmother=123" +
 				"\tfather=124" +
@@ -40,8 +40,8 @@ namespace ImperatorToCK3.UnitTests.Imperator.Characters {
 			var spouse1Reader = new BufferedReader(string.Empty);
 			var spouse2Reader = new BufferedReader(string.Empty);
 			character.Spouses = new() {
-				{ 69, ImperatorToCK3.Imperator.Characters.Character.Parse(spouse1Reader, "69", genesDB) },
-				{ 420, ImperatorToCK3.Imperator.Characters.Character.Parse(spouse2Reader, "420", genesDB) }
+				{ 3, ImperatorToCK3.Imperator.Characters.Character.Parse(spouse1Reader, "3", genesDB) },
+				{ 4, ImperatorToCK3.Imperator.Characters.Character.Parse(spouse2Reader, "4", genesDB) }
 			};
 
 			Assert.Equal((ulong)42, character.Id);
@@ -66,14 +66,25 @@ namespace ImperatorToCK3.UnitTests.Imperator.Characters {
 			Assert.Equal("killed_in_battle", character.DeathReason);
 			Assert.Collection(character.Spouses,
 				item => {
-					Assert.Equal((ulong)69, item.Key);
-					Assert.Equal((ulong)69, item.Value.Id);
+					Assert.Equal((ulong)3, item.Key);
+					Assert.Equal((ulong)3, item.Value.Id);
 				},
 				item => {
-					Assert.Equal((ulong)420, item.Key);
-					Assert.Equal((ulong)420, item.Value.Id);
+					Assert.Equal((ulong)4, item.Key);
+					Assert.Equal((ulong)4, item.Value.Id);
 				}
 			);
+
+			Assert.Empty(character.Children); // children not linked yet
+			var characters = new ImperatorToCK3.Imperator.Characters.Characters();
+			characters.Add(character);
+			var child1 = ImperatorToCK3.Imperator.Characters.Character.Parse(new BufferedReader("={ mother=42 }"), "69", null);
+			var child2 = ImperatorToCK3.Imperator.Characters.Character.Parse(new BufferedReader("={ mother=42 }"), "420", null);
+			characters.Add(child1);
+			characters.Add(child2);
+			child1.LinkMother(characters);
+			child2.LinkMother(characters);
+
 			Assert.Collection(character.Children,
 				item => {
 					Assert.Equal((ulong)69, item.Key);

--- a/ImperatorToCK3.UnitTests/Imperator/Characters/CharactersTests.cs
+++ b/ImperatorToCK3.UnitTests/Imperator/Characters/CharactersTests.cs
@@ -24,13 +24,11 @@ namespace ImperatorToCK3.UnitTests.Imperator.Characters {
 			var characters = new ImperatorToCK3.Imperator.Characters.Characters(reader, genesDB);
 
 			Assert.Collection(characters.StoredCharacters,
-				item => {
-					Assert.Equal((ulong)42, item.Key);
-					Assert.Equal((ulong)42, item.Value.Id);
+				character => {
+					Assert.Equal((ulong)42, character.Id);
 				},
-				item => {
-					Assert.Equal((ulong)43, item.Key);
-					Assert.Equal((ulong)43, item.Value.Id);
+				character => {
+					Assert.Equal((ulong)43, character.Id);
 				}
 			);
 		}
@@ -43,7 +41,7 @@ namespace ImperatorToCK3.UnitTests.Imperator.Characters {
 				"}"
 			);
 			var characters = new ImperatorToCK3.Imperator.Characters.Characters(reader, genesDB);
-			Assert.Equal((ulong)42, characters.StoredCharacters[43].Spouses[42].Id);
+			Assert.Equal((ulong)42, characters[43].Spouses[42].Id);
 		}
 
 		[Fact]
@@ -54,7 +52,7 @@ namespace ImperatorToCK3.UnitTests.Imperator.Characters {
 				"}"
 			);
 			var characters = new ImperatorToCK3.Imperator.Characters.Characters(reader, genesDB);
-			Assert.Empty(characters.StoredCharacters[43].Spouses);
+			Assert.Empty(characters[43].Spouses);
 		}
 	}
 }

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -60,7 +60,7 @@ namespace ImperatorToCK3.CK3.Titles {
 		public Title(
 			Governorship governorship,
 			Country country,
-			Dictionary<ulong, Character> imperatorCharacters,
+			Imperator.Characters.Characters imperatorCharacters,
 			bool regionHasMultipleGovernorships,
 			LocalizationMapper localizationMapper,
 			LandedTitles landedTitles,
@@ -251,7 +251,7 @@ namespace ImperatorToCK3.CK3.Titles {
 
 		public void InitializeFromGovernorship(Governorship governorship,
 			Country country,
-			Dictionary<ulong, Character> imperatorCharacters,
+			Imperator.Characters.Characters imperatorCharacters,
 			bool regionHasMultipleGovernorships,
 			LocalizationMapper localizationMapper,
 			LandedTitles landedTitles,

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -102,7 +102,7 @@ namespace ImperatorToCK3.CK3 {
 		private void ImportImperatorCharacters(Imperator.World impWorld, Date endDate, Date ck3BookmarkDate) {
 			Logger.Info("Importing Imperator Characters...");
 
-			foreach (var character in impWorld.Characters.StoredCharacters.Values) {
+			foreach (var character in impWorld.Characters.StoredCharacters) {
 				ImportImperatorCharacter(character, endDate, ck3BookmarkDate);
 			}
 			Logger.Info($"{Characters.Count} total characters recognized.");
@@ -192,7 +192,6 @@ namespace ImperatorToCK3.CK3 {
 
 			var governorships = impWorld.Jobs.Governorships;
 			var imperatorCountries = impWorld.Countries.StoredCountries;
-			var imperatorCharacters = impWorld.Characters.StoredCharacters;
 
 			var governorshipsPerRegion = governorships.GroupBy(g => g.RegionName)
 				.ToDictionary(g => g.Key, g => g.Count());
@@ -204,7 +203,7 @@ namespace ImperatorToCK3.CK3 {
 				ImportImperatorGovernorship(
 					governorship,
 					imperatorCountries,
-					imperatorCharacters,
+					impWorld.Characters,
 					governorshipsPerRegion[governorship.RegionName] > 1
 				);
 				++counter;
@@ -214,7 +213,7 @@ namespace ImperatorToCK3.CK3 {
 		private void ImportImperatorGovernorship(
 			Governorship governorship,
 			Dictionary<ulong, Country> imperatorCountries,
-			Dictionary<ulong, Imperator.Characters.Character> imperatorCharacters,
+			Imperator.Characters.Characters imperatorCharacters,
 			bool regionHasMultipleGovernorships
 		) {
 			var country = imperatorCountries[governorship.CountryID];


### PR DESCRIPTION
`characters.StoredCharacters.Add(id, character)` is a bit ugly and allows a mismatch between character id and key in the dictionary.
`characters.Add(character)` is safer and prettier.