### PR TITLE
Simplify LandedTitles code with clever inheritance

### DIFF
--- a/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
@@ -12,7 +12,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 			var titles = new LandedTitles();
 			titles.LoadTitles(reader);
 
-			Assert.Empty(titles.StoredTitles);
+			Assert.Empty(titles);
 		}
 
 		[Fact]
@@ -25,10 +25,10 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 			var titles = new LandedTitles();
 			titles.LoadTitles(reader);
 
-			var barony = titles.StoredTitles["b_barony"];
-			var county = titles.StoredTitles["c_county"];
+			var barony = titles["b_barony"];
+			var county = titles["c_county"];
 
-			Assert.Equal(2, titles.StoredTitles.Count);
+			Assert.Equal(2, titles.Count);
 			Assert.Equal((ulong)12, barony.Province);
 			Assert.True(county.Landless);
 		}
@@ -43,10 +43,10 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 			var titles = new LandedTitles();
 			titles.LoadTitles(reader);
 
-			var barony = titles.StoredTitles["b_barony4"];
-			var county = titles.StoredTitles["c_county5"];
+			var barony = titles["b_barony4"];
+			var county = titles["c_county5"];
 
-			Assert.Equal(5, titles.StoredTitles.Count);
+			Assert.Equal(5, titles.Count);
 			Assert.Equal((ulong)12, barony.Province);
 			Assert.True(county.Landless);
 		}
@@ -67,10 +67,10 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 			);
 			titles.LoadTitles(reader2);
 
-			var barony = titles.StoredTitles["b_barony4"];
-			var county = titles.StoredTitles["c_county5"];
+			var barony = titles["b_barony4"];
+			var county = titles["c_county5"];
 
-			Assert.Equal(5, titles.StoredTitles.Count);
+			Assert.Equal(5, titles.Count);
 			Assert.Equal((ulong)15, barony.Province);
 			Assert.False(county.Landless);
 		}
@@ -92,7 +92,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 			);
 			titles.LoadTitles(reader2);
 
-			Assert.Equal(10, titles.StoredTitles.Count);
+			Assert.Equal(10, titles.Count);
 		}
 
 		[Fact]
@@ -105,7 +105,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 			var titles = new LandedTitles();
 			titles.LoadTitles(reader);
 
-			var empire = titles.StoredTitles["e_empire"];
+			var empire = titles["e_empire"];
 			var capitalCounty = empire.CapitalCounty;
 			Assert.NotNull(capitalCounty);
 			Assert.Equal("c_county", capitalCounty.Name);

--- a/ImperatorToCK3/CK3/Characters/Characters.cs
+++ b/ImperatorToCK3/CK3/Characters/Characters.cs
@@ -132,7 +132,7 @@ namespace ImperatorToCK3.CK3.Characters {
 		}
 
 		public void PurgeLandlessVanillaCharacters(LandedTitles titles, Date ck3BookmarkDate) {
-			var landedCharacterIdSelect = titles.StoredTitles.Values.Select(t => t.GetHolderId(ck3BookmarkDate));
+			var landedCharacterIdSelect = titles.Values.Select(t => t.GetHolderId(ck3BookmarkDate));
 			var farewellIds = Keys.Where(
 				id => !id.StartsWith("imperator") && !landedCharacterIdSelect.Contains(id)
 			);

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -463,10 +463,8 @@ namespace ImperatorToCK3.CK3.Titles {
 		}
 		public void AddHistory(LandedTitles landedTitles, TitleHistory titleHistory) {
 			history = titleHistory;
-			if (history.Liege is not null) {
-				if (landedTitles.StoredTitles.TryGetValue(history.Liege, out var liege)) {
-					DeFactoLiege = liege;
-				}
+			if (history.Liege is not null && landedTitles.TryGetValue(history.Liege, out var liege)) {
+				DeFactoLiege = liege;
 			}
 		}
 

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -26,8 +26,7 @@ namespace ImperatorToCK3.CK3 {
 		public Characters.Characters Characters { get; } = new();
 		public Dictionary<string, Dynasty> Dynasties { get; } = new();
 		public Dictionary<ulong, Province> Provinces { get; } = new();
-		private readonly LandedTitles landedTitles = new();
-		public Dictionary<string, Title> LandedTitles => landedTitles.StoredTitles;
+		public LandedTitles LandedTitles { get; } = new();
 		public Map.MapData MapData { get; }
 
 		public World(Imperator.World impWorld, Configuration theConfiguration) {
@@ -48,11 +47,11 @@ namespace ImperatorToCK3.CK3 {
 
 			// Load vanilla CK3 landed titles
 			var landedTitlesPath = Path.Combine(theConfiguration.Ck3Path, "game/common/landed_titles/00_landed_titles.txt");
-			landedTitles.LoadTitles(landedTitlesPath);
+			LandedTitles.LoadTitles(landedTitlesPath);
 			AddHistoryToVanillaTitles();
 
 			// Loading regions
-			ck3RegionMapper = new CK3RegionMapper(theConfiguration.Ck3Path, landedTitles);
+			ck3RegionMapper = new CK3RegionMapper(theConfiguration.Ck3Path, LandedTitles);
 			imperatorRegionMapper = new ImperatorRegionMapper(theConfiguration.ImperatorPath);
 			// Use the region mappers in other mappers
 			religionMapper.LoadRegionMappers(imperatorRegionMapper, ck3RegionMapper);
@@ -87,7 +86,7 @@ namespace ImperatorToCK3.CK3 {
 			OverWriteCountiesHistory(impWorld.Jobs.Governorships, theConfiguration.Ck3BookmarkDate);
 			RemoveInvalidLandlessTitles(theConfiguration.Ck3BookmarkDate);
 
-			Characters.PurgeLandlessVanillaCharacters(landedTitles, theConfiguration.Ck3BookmarkDate);
+			Characters.PurgeLandlessVanillaCharacters(LandedTitles, theConfiguration.Ck3BookmarkDate);
 		}
 
 		private void ClearFeaturedCharactersDescriptions(Date ck3BookmarkDate) {
@@ -129,7 +128,7 @@ namespace ImperatorToCK3.CK3 {
 					country,
 					imperatorCountries,
 					localizationMapper,
-					landedTitles,
+					LandedTitles,
 					provinceMapper,
 					coaMapper,
 					governmentMapper,
@@ -145,7 +144,7 @@ namespace ImperatorToCK3.CK3 {
 					country,
 					imperatorCountries,
 					localizationMapper,
-					landedTitles,
+					LandedTitles,
 					provinceMapper,
 					coaMapper,
 					tagTitleMapper,
@@ -157,7 +156,7 @@ namespace ImperatorToCK3.CK3 {
 					nicknameMapper,
 					Characters
 				);
-				landedTitles.InsertTitle(newTitle);
+				LandedTitles.InsertTitle(newTitle);
 			}
 		}
 
@@ -201,7 +200,7 @@ namespace ImperatorToCK3.CK3 {
 					imperatorCharacters,
 					regionHasMultipleGovernorships,
 					localizationMapper,
-					landedTitles,
+					LandedTitles,
 					provinceMapper,
 					definiteFormMapper,
 					imperatorRegionMapper
@@ -213,14 +212,14 @@ namespace ImperatorToCK3.CK3 {
 					imperatorCharacters,
 					regionHasMultipleGovernorships,
 					localizationMapper,
-					landedTitles,
+					LandedTitles,
 					provinceMapper,
 					coaMapper,
 					tagTitleMapper,
 					definiteFormMapper,
 					imperatorRegionMapper
 				);
-				landedTitles.InsertTitle(newTitle);
+				LandedTitles.InsertTitle(newTitle);
 			}
 		}
 
@@ -360,7 +359,7 @@ namespace ImperatorToCK3.CK3 {
 			foreach (var (name, title) in LandedTitles) {
 				var historyOpt = titlesHistory.PopTitleHistory(name);
 				if (historyOpt is not null) {
-					title.AddHistory(landedTitles, historyOpt);
+					title.AddHistory(LandedTitles, historyOpt);
 				}
 			}
 			// add vanilla development to counties
@@ -479,7 +478,7 @@ namespace ImperatorToCK3.CK3 {
 					if (!LandedTitles[name].Landless) { // does not have landless attribute set to true
 						if (title.IsImportedOrUpdatedFromImperator && name.Contains("IMPTOCK3")) {
 							removedGeneratedTitles.Add(name);
-							landedTitles.EraseTitle(name);
+							LandedTitles.EraseTitle(name);
 						} else {
 							revokedVanillaTitles.Add(name);
 							title.ClearHolderSpecificHistory();

--- a/ImperatorToCK3/Mappers/Region/CK3RegionMapper.cs
+++ b/ImperatorToCK3/Mappers/Region/CK3RegionMapper.cs
@@ -20,7 +20,7 @@ namespace ImperatorToCK3.Mappers.Region {
 			ParseFile(islandRegionFilePath);
 			ClearRegisteredRules();
 
-			foreach (var (titleName, title) in landedTitles.StoredTitles) {
+			foreach (var (titleName, title) in landedTitles) {
 				var titleRank = title.Rank;
 				if (titleRank == TitleRank.county) {
 					counties[titleName] = title;


### PR DESCRIPTION
By making LandedTitles itself a `Dictionary<string, Title>`, we alleviate the need for StoredTitles property.