### PR TITLE
Refined Imperator Territory -> CK3 Holding mapping

### DIFF
--- a/ImperatorToCK3/CK3/Provinces/Province.cs
+++ b/ImperatorToCK3/CK3/Provinces/Province.cs
@@ -155,6 +155,9 @@ namespace ImperatorToCK3.CK3.Provinces {
 					case Imperator.Countries.GovernmentType.monarchy:
 						details.Holding = "castle_holding";
 						break;
+					default:
+						details.Holding = "none";
+						break;
 				}
 			} else {
 				switch (ImperatorProvince.ProvinceRank) {
@@ -226,6 +229,9 @@ namespace ImperatorToCK3.CK3.Provinces {
 								details.Holding = "tribal_holding";
 								break;
 						}
+						break;
+					default:
+						details.Holding = "none";
 						break;
 				}
 			}

--- a/ImperatorToCK3/CK3/Provinces/Province.cs
+++ b/ImperatorToCK3/CK3/Provinces/Province.cs
@@ -143,72 +143,92 @@ namespace ImperatorToCK3.CK3.Provinces {
 				return;
 			}
 
-			switch (ImperatorProvince.ProvinceRank) {
-				case Imperator.Provinces.ProvinceRank.city_metropolis:					
-				case Imperator.Provinces.ProvinceRank.city:
-					switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
-						case Imperator.Countries.GovernmentType.tribal:							
-							if (ImperatorProvince.HolySite) {
-								details.Holding = "church_holding";
-							} else {
-								details.Holding = "city_holding";
-							}
-							break;
-						case Imperator.Countries.GovernmentType.republic:
-							if (ImperatorProvince.HolySite) {
-								details.Holding = "church_holding";
-							} else {
-								details.Holding = "city_holding";
-							}
-							break;
-						case Imperator.Countries.GovernmentType.monarchy:
-							if (ImperatorProvince.Fort) {
-								details.Holding = "castle_holding";
-							} else {
+			
+			if (this.IsCountyCapital(landedTitles)) {
+				// CK3 Holdings that are Provincial Capitals always match the Government Type
+				switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
+					case Imperator.Countries.GovernmentType.tribal:
+						details.Holding = "tribal_holding";
+						break;
+					case Imperator.Countries.GovernmentType.republic:
+						details.Holding = "city_holding";
+						break;
+					case Imperator.Countries.GovernmentType.monarchy:
+						details.Holding = "castle_holding";
+						break;
+				}
+			} else {
+				switch (ImperatorProvince.ProvinceRank) {
+					case Imperator.Provinces.ProvinceRank.city_metropolis:
+					case Imperator.Provinces.ProvinceRank.city:
+						switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
+							case Imperator.Countries.GovernmentType.tribal:
+								if (ImperatorProvince.HolySite) {
+									details.Holding = "church_holding";
+								} else {
+									if (ImperatorProvince.Fort) {
+										details.Holding = "castle_holding";
+									} else {
+										details.Holding = "city_holding";
+									}
+								}
+								break;
+							case Imperator.Countries.GovernmentType.republic:
 								if (ImperatorProvince.HolySite) {
 									details.Holding = "church_holding";
 								} else {
 									details.Holding = "city_holding";
 								}
-							}
-							break;
-						default:
-							details.Holding = "city_holding";
-							break;
-					}
-					break;
-				case Imperator.Provinces.ProvinceRank.settlement:
-					switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
-						case Imperator.Countries.GovernmentType.tribal:							
-							if (ImperatorProvince.HolySite) {
-								details.Holding = "church_holding";
-							} else {
-								details.Holding = "tribal_holding";
-							}
-							break;
-						case Imperator.Countries.GovernmentType.republic:
-							if (ImperatorProvince.HolySite) {
-								details.Holding = "church_holding";
-							} else {
-								details.Holding = "city_holding";
-							}
-							break;
-						case Imperator.Countries.GovernmentType.monarchy:
-							if (ImperatorProvince.Fort) {
-								details.Holding = "castle_holding";
-							} else {
+								break;
+							case Imperator.Countries.GovernmentType.monarchy:
 								if (ImperatorProvince.HolySite) {
 									details.Holding = "church_holding";
-								} else {									
-									details.Holding = "city_holding";
+								} else {
+									if (ImperatorProvince.Fort) {
+										details.Holding = "castle_holding";
+									} else {
+										details.Holding = "city_holding";
+									}
 								}
-							}
-							break;
-						default:
-							details.Holding = "city_holding";
-							break;
-					}
-					break;					
+								break;
+							default:
+								details.Holding = "city_holding";
+								break;
+						}
+						break;
+					case Imperator.Provinces.ProvinceRank.settlement:
+						switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
+							case Imperator.Countries.GovernmentType.tribal:
+								details.Holding = "none";
+								break;
+							case Imperator.Countries.GovernmentType.republic:
+								if (ImperatorProvince.HolySite) {
+									details.Holding = "church_holding";
+								} else {
+									if (ImperatorProvince.Fort) {
+										details.Holding = "city_holding";
+									} else {
+										details.Holding = "none";
+									}
+								}
+								break;
+							case Imperator.Countries.GovernmentType.monarchy:
+								if (ImperatorProvince.HolySite) {
+									details.Holding = "church_holding";
+								} else {
+									if (ImperatorProvince.Fort) {
+										details.Holding = "castle_holding";
+									} else {
+										details.Holding = "none";
+									}
+								}
+								break;
+							default:
+								details.Holding = "tribal_holding";
+								break;
+						}
+						break;
+				}
 			}
 		}
 

--- a/ImperatorToCK3/CK3/Provinces/Province.cs
+++ b/ImperatorToCK3/CK3/Provinces/Province.cs
@@ -142,8 +142,7 @@ namespace ImperatorToCK3.CK3.Provinces {
 				Logger.Warn($"CK3 Province {Id}: Imperator Province Owner Country is null!");
 				return;
 			}
-
-			
+						
 			if (this.IsCountyCapital(landedTitles)) {
 				// CK3 Holdings that are Provincial Capitals always match the Government Type
 				switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {

--- a/ImperatorToCK3/CK3/Provinces/Province.cs
+++ b/ImperatorToCK3/CK3/Provinces/Province.cs
@@ -135,26 +135,77 @@ namespace ImperatorToCK3.CK3.Provinces {
 				return;
 			}
 
+			if (ImperatorProvince.OwnerCountry.Value is null) {
+				Logger.Warn($"CK3 Province {Id}: Imperator Province Owner Country is null!");
+				return;
+			}
+
 			switch (ImperatorProvince.ProvinceRank) {
-				case Imperator.Provinces.ProvinceRank.city_metropolis:
-					details.Holding = "city_holding";
-					break;
+				case Imperator.Provinces.ProvinceRank.city_metropolis:					
 				case Imperator.Provinces.ProvinceRank.city:
-					if (ImperatorProvince.Fort) {
-						details.Holding = "castle_holding";
-					} else {
-						details.Holding = "city_holding";
+					switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
+						case Imperator.Countries.GovernmentType.tribal:							
+							if (ImperatorProvince.HolySite) {
+								details.Holding = "church_holding";
+							} else {
+								details.Holding = "city_holding";
+							}
+							break;
+						case Imperator.Countries.GovernmentType.republic:
+							if (ImperatorProvince.HolySite) {
+								details.Holding = "church_holding";
+							} else {
+								details.Holding = "city_holding";
+							}
+							break;
+						case Imperator.Countries.GovernmentType.monarchy:
+							if (ImperatorProvince.Fort) {
+								details.Holding = "castle_holding";
+							} else {
+								if (ImperatorProvince.HolySite) {
+									details.Holding = "church_holding";
+								} else {
+									details.Holding = "city_holding";
+								}
+							}
+							break;
+						default:
+							details.Holding = "city_holding";
+							break;
 					}
 					break;
 				case Imperator.Provinces.ProvinceRank.settlement:
-					if (ImperatorProvince.HolySite) {
-						details.Holding = "church_holding";
-					} else if (ImperatorProvince.Fort) {
-						details.Holding = "castle_holding";
-					} else {
-						details.Holding = "tribal_holding";
+					switch (ImperatorProvince.OwnerCountry.Value.GovernmentType) {
+						case Imperator.Countries.GovernmentType.tribal:							
+							if (ImperatorProvince.HolySite) {
+								details.Holding = "church_holding";
+							} else {
+								details.Holding = "tribal_holding";
+							}
+							break;
+						case Imperator.Countries.GovernmentType.republic:
+							if (ImperatorProvince.HolySite) {
+								details.Holding = "church_holding";
+							} else {
+								details.Holding = "city_holding";
+							}
+							break;
+						case Imperator.Countries.GovernmentType.monarchy:
+							if (ImperatorProvince.Fort) {
+								details.Holding = "castle_holding";
+							} else {
+								if (ImperatorProvince.HolySite) {
+									details.Holding = "church_holding";
+								} else {									
+									details.Holding = "city_holding";
+								}
+							}
+							break;
+						default:
+							details.Holding = "city_holding";
+							break;
 					}
-					break;
+					break;					
 			}
 		}
 	}


### PR DESCRIPTION
Refined Imperator Territory -> CK3 Holding mapping (No more spamming non-Tribal realms with Tribal Holdings, also Metropolises with Forts are considered as Castle Holdings for Monarchies)