### PR TITLE
Fix Imperator provinces without owners being logged

### DIFF
--- a/ImperatorToCK3/CK3/Provinces/Province.cs
+++ b/ImperatorToCK3/CK3/Provinces/Province.cs
@@ -139,12 +139,12 @@ namespace ImperatorToCK3.CK3.Provinces {
 			}
 
 			if (ImperatorProvince.OwnerCountry is null) {
-				Logger.Warn($"CK3 Province {Id}: Imperator Province Owner Country is null!");
+				details.Holding = "none";
 				return;
 			}
 
 			if (IsCountyCapital(landedTitles)) {
-				// CK3 Holdings that are Provincial Capitals always match the Government Type
+				// CK3 Holdings that are county capitals always match the Government Type
 				switch (ImperatorProvince.OwnerCountry.GovernmentType) {
 					case Imperator.Countries.GovernmentType.tribal:
 						details.Holding = "tribal_holding";

--- a/ImperatorToCK3/Imperator/Provinces/Provinces.cs
+++ b/ImperatorToCK3/Imperator/Provinces/Provinces.cs
@@ -25,7 +25,7 @@ namespace ImperatorToCK3.Imperator.Provinces {
 		}
 		public void LinkCountries(Countries.Countries countries) {
 			var counter = Values.Count(province => province.TryLinkOwnerCounty(countries));
-			Logger.Info($"{counter} countries linked to provinces.");
+			Logger.Info($"{counter} provinces linked to countries.");
 		}
 
 		public void Add(Province province) {


### PR DESCRIPTION
It's fine if an Imperator provinces has no owner, this happens when it's uncolonised or impassable.