### PR TITLE
Rename succession triggers file

### DIFF
--- a/ImperatorToCK3/Outputter/SuccessionTriggersOutputter.cs
+++ b/ImperatorToCK3/Outputter/SuccessionTriggersOutputter.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace ImperatorToCK3.Outputter {
 	public static class SuccessionTriggersOutputter {
 		public static void OutputSuccessionTriggers(string outputModName, LandedTitles landedTitles) {
-			var outputPath = Path.Combine("output", outputModName, "common/scripted_triggers/00_succession_triggers.txt");
+			var outputPath = Path.Combine("output", outputModName, "common/scripted_triggers/IRToCK3_succession_triggers.txt");
 
 			using var outputStream = File.OpenWrite(outputPath);
 			using var output = new StreamWriter(outputStream, System.Text.Encoding.UTF8);


### PR DESCRIPTION
Naming the file same as vanilla one did cause missing trigger errors in error.log.