### PR TITLE
Development conversion

### DIFF
--- a/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
@@ -238,6 +238,27 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 		}
 
 		[Fact]
+		public void DevelopmentIsCorrectlyCalculatedFor1ProvinceTo1BaronyCountyMapping() {
+			var date = new Date(476, 1, 1);
+			var titles = new Title.LandedTitles();
+			var titlesReader = new BufferedReader(
+				"c_county1={ b_barony1={province=1} } "
+			);
+			titles.LoadTitles(titlesReader);
+
+			var imperatorProvinces = new ImperatorToCK3.Imperator.Provinces.ProvinceCollection();
+			var impProv = new ImperatorToCK3.Imperator.Provinces.Province(1) { CivilizationValue = 25 };
+			imperatorProvinces.Add(impProv);
+
+			var mappingsReader = new BufferedReader("0.0.0.0={ link={ imp=1 ck3=1 } }");
+			var provMapper = new ProvinceMapper(mappingsReader);
+
+			titles.ImportDevelopmentFromImperator(imperatorProvinces, provMapper, date);
+
+			Assert.Equal(20, titles["c_county1"].GetDevelopmentLevel(date)); // 25 - sqrt(25)
+		}
+
+		[Fact]
 		public void DevelopmentFromImperatorProvinceCanBeSplitForTargetProvinces() {
 			var date = new Date(476, 1, 1);
 			var titles = new Title.LandedTitles();

--- a/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
@@ -221,5 +221,71 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 				}
 			);
 		}
+
+		[Fact]
+		public void DevelopmentIsNotChangedForCountiesOutsideOfImperatorMap() {
+			var date = new Date(476, 1, 1);
+			var titles = new Title.LandedTitles();
+			var county = titles.Add("c_county");
+			county.SetDevelopmentLevel(33, date);
+
+			var imperatorProvinces = new ImperatorToCK3.Imperator.Provinces.ProvinceCollection();
+			var provMapper = new ProvinceMapper();
+
+			titles.ImportDevelopmentFromImperator(imperatorProvinces, provMapper, date);
+
+			Assert.Equal(33, county.GetDevelopmentLevel(date));
+		}
+
+		[Fact]
+		public void DevelopmentFromImperatorProvinceCanBeSplitForTargetProvinces() {
+			var date = new Date(476, 1, 1);
+			var titles = new Title.LandedTitles();
+			var titlesReader = new BufferedReader(
+				"c_county1={ b_barony1={province=1} } " +
+				"c_county2={ b_barony2={province=2} } " +
+				"c_county3={ b_barony3={province=3} } "
+			);
+			titles.LoadTitles(titlesReader);
+
+			var imperatorProvinces = new ImperatorToCK3.Imperator.Provinces.ProvinceCollection();
+			var impProv = new ImperatorToCK3.Imperator.Provinces.Province(1) { CivilizationValue = 21 };
+			imperatorProvinces.Add(impProv);
+
+			var mappingsReader = new BufferedReader("0.0.0.0={ link={ imp=1 ck3=1 ck3=2 ck3=3 } }");
+			var provMapper = new ProvinceMapper(mappingsReader);
+
+			titles.ImportDevelopmentFromImperator(imperatorProvinces, provMapper, date);
+
+			Assert.Equal(7, titles["c_county1"].GetDevelopmentLevel(date));
+			Assert.Equal(7, titles["c_county2"].GetDevelopmentLevel(date));
+			Assert.Equal(7, titles["c_county3"].GetDevelopmentLevel(date));
+		}
+
+		[Fact]
+		public void DevelopmentOfCountyIsCalculatedFromAllCountyProvinces() {
+			var date = new Date(476, 1, 1);
+			var titles = new Title.LandedTitles();
+			var titlesReader = new BufferedReader(
+				"c_county1={ b_barony1={province=1} b_barony2={province=2} } "
+			);
+			titles.LoadTitles(titlesReader);
+
+			var imperatorProvinces = new ImperatorToCK3.Imperator.Provinces.ProvinceCollection();
+			var impProv1 = new ImperatorToCK3.Imperator.Provinces.Province(1) { CivilizationValue = 10 };
+			imperatorProvinces.Add(impProv1);
+			var impProv2 = new ImperatorToCK3.Imperator.Provinces.Province(2) { CivilizationValue = 40 };
+			imperatorProvinces.Add(impProv2);
+
+			var mappingsReader = new BufferedReader("0.0.0.0={" +
+													" link={ imp=1 ck3=1 } " +
+													" link={ imp=2 ck3=2 } " +
+													"}");
+			var provMapper = new ProvinceMapper(mappingsReader);
+
+			titles.ImportDevelopmentFromImperator(imperatorProvinces, provMapper, date);
+
+			Assert.Equal(25, titles["c_county1"].GetDevelopmentLevel(date)); // (10+40)/2
+		}
 	}
 }

--- a/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Titles/LandedTitlesTests.cs
@@ -257,9 +257,9 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 
 			titles.ImportDevelopmentFromImperator(imperatorProvinces, provMapper, date);
 
-			Assert.Equal(7, titles["c_county1"].GetDevelopmentLevel(date));
-			Assert.Equal(7, titles["c_county2"].GetDevelopmentLevel(date));
-			Assert.Equal(7, titles["c_county3"].GetDevelopmentLevel(date));
+			Assert.Equal(4, titles["c_county1"].GetDevelopmentLevel(date)); // 7 - sqrt(7)
+			Assert.Equal(4, titles["c_county2"].GetDevelopmentLevel(date)); // same
+			Assert.Equal(4, titles["c_county3"].GetDevelopmentLevel(date)); // same
 		}
 
 		[Fact]
@@ -285,7 +285,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Titles {
 
 			titles.ImportDevelopmentFromImperator(imperatorProvinces, provMapper, date);
 
-			Assert.Equal(25, titles["c_county1"].GetDevelopmentLevel(date)); // (10+40)/2
+			Assert.Equal(20, titles["c_county1"].GetDevelopmentLevel(date)); // (10+40)/2 - sqrt(25)
 		}
 	}
 }

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -494,8 +494,11 @@ public partial class Title {
 				double dev = 0;
 				var countyProvinces = county.CountyProvinces;
 				foreach (var ck3ProvId in countyProvinces) {
-					dev += provMapper.GetImperatorProvinceNumbers(ck3ProvId)
-						.Sum(impProvId => imperatorProvinces[impProvId].CivilizationValue / ck3ProvsPerImperatorProv[impProvId]);
+					var impProvs = provMapper.GetImperatorProvinceNumbers(ck3ProvId);
+					if (impProvs.Count == 0) {
+						continue;
+					}
+					dev += impProvs.Average(impProvId => imperatorProvinces[impProvId].CivilizationValue / ck3ProvsPerImperatorProv[impProvId]);
 				}
 
 				var provsCount = countyProvinces.Count();

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -500,6 +500,7 @@ public partial class Title {
 
 				var provsCount = countyProvinces.Count();
 				dev /= provsCount;
+				dev -= Math.Sqrt(dev);
 
 				county.history.InternalHistory.Fields.Remove("development_level");
 				county.history.InternalHistory.AddFieldValue("development_level", (int)dev, date, "change_development_level");

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -497,7 +497,9 @@ public partial class Title {
 					dev += provMapper.GetImperatorProvinceNumbers(ck3ProvId)
 						.Sum(impProvId => imperatorProvinces[impProvId].CivilizationValue / ck3ProvsPerImperatorProv[impProvId]);
 				}
-				dev /= countyProvinces.Count();
+
+				var provsCount = countyProvinces.Count();
+				dev /= provsCount * Math.Sqrt(provsCount);
 
 				county.history.InternalHistory.Fields.Remove("development_level");
 				county.history.InternalHistory.AddFieldValue("development_level", (int)dev, correctedDate, "change_development_level");

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -465,7 +465,7 @@ public partial class Title {
 			return countyHoldersCache;
 		}
 
-		public void ImportDevelopmentFromImperator(Imperator.Provinces.ProvinceCollection imperatorProvinces, ProvinceMapper provMapper, Date correctedDate) {
+		public void ImportDevelopmentFromImperator(Imperator.Provinces.ProvinceCollection imperatorProvinces, ProvinceMapper provMapper, Date date) {
 			Logger.Info("Importing development from Imperator...");
 
 			var counties = this.Where(t => t.Rank == TitleRank.county);
@@ -499,10 +499,10 @@ public partial class Title {
 				}
 
 				var provsCount = countyProvinces.Count();
-				dev /= provsCount * Math.Sqrt(provsCount);
+				dev /= provsCount;
 
 				county.history.InternalHistory.Fields.Remove("development_level");
-				county.history.InternalHistory.AddFieldValue("development_level", (int)dev, correctedDate, "change_development_level");
+				county.history.InternalHistory.AddFieldValue("development_level", (int)dev, date, "change_development_level");
 			}
 		}
 	}

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -114,6 +114,7 @@ namespace ImperatorToCK3.CK3 {
 			Dynasties.ImportImperatorFamilies(impWorld, locDB);
 
 			OverWriteCountiesHistory(impWorld.Jobs.Governorships, countyLevelGovernorships, impWorld.Characters, CorrectedDate);
+			LandedTitles.ImportDevelopmentFromImperator(impWorld.Provinces, provinceMapper, CorrectedDate);
 			LandedTitles.RemoveInvalidLandlessTitles(config.CK3BookmarkDate);
 			LandedTitles.SetDeJureKingdomsAndEmpires(config.CK3BookmarkDate);
 


### PR DESCRIPTION
CK3 development is converted from Imperator civilisation value (1 civ value = 1 dev level).
When an Imperator province is mapped to multiple CK3 provinces, its civ value is split between them.
For every county I sum the calculated development from provinces, then divide by the number of provinces. Then subtract a square root of that.
Development for counties outside of Imperator map is kept from vanilla.