### PR TITLE
Replace CK3 owner with Imperator historical tag in CultureMapper

### DIFF
--- a/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
@@ -1,11 +1,11 @@
 ﻿using commonItems;
 using commonItems.Localization;
 using ImperatorToCK3.CK3.Characters;
-using ImperatorToCK3.CK3.Titles;
 using ImperatorToCK3.Mappers.Culture;
 using ImperatorToCK3.Mappers.DeathReason;
 using ImperatorToCK3.Mappers.Nickname;
 using ImperatorToCK3.Mappers.Province;
+using ImperatorToCK3.Mappers.Region;
 using ImperatorToCK3.Mappers.Religion;
 using ImperatorToCK3.Mappers.Trait;
 using System;
@@ -183,7 +183,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 				"link = { imp=chalcedonian ck3=orthodox }"
 			);
 			var religionMapper = new ReligionMapper(mapReader);
-			religionMapper.LoadRegionMappers(new ImperatorToCK3.Mappers.Region.ImperatorRegionMapper(), new ImperatorToCK3.Mappers.Region.CK3RegionMapper());
+			religionMapper.LoadRegionMappers(new ImperatorRegionMapper(), new CK3RegionMapper());
 
 			var character = builder
 				.WithImperatorCharacter(imperatorCharacter)
@@ -203,8 +203,8 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 			);
 			var cultureMapper = new CultureMapper(mapReader);
 			cultureMapper.LoadRegionMappers(
-				new ImperatorToCK3.Mappers.Region.ImperatorRegionMapper(),
-				new ImperatorToCK3.Mappers.Region.CK3RegionMapper()
+				new ImperatorRegionMapper(),
+				new CK3RegionMapper()
 			);
 
 			var character = builder
@@ -216,11 +216,8 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 
 		[Fact]
 		public void ImperatorCountryOfCharacterIsUsedForCultureConversion() {
-			var countryReader = new BufferedReader("tag = RAN");
+			var countryReader = new BufferedReader("tag = MAC");
 			var country = ImperatorToCK3.Imperator.Countries.Country.Parse(countryReader, 69);
-
-			var titles = new Title.LandedTitles();
-			country.CK3Title = titles.Add("d_rankless");
 
 			var imperatorCharacter1 = new ImperatorToCK3.Imperator.Characters.Character(1) {
 				Culture = "greek",
@@ -231,11 +228,11 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 			};
 
 			var mapReader = new BufferedReader(
-				"link = { imp=greek ck3=macedonian owner=d_rankless }" +
+				"link = { imp=greek ck3=macedonian tag=MAC }" +
 				"link = { imp=greek ck3=greek }"
 			);
 			var cultureMapper = new CultureMapper(mapReader);
-			cultureMapper.LoadRegionMappers(new ImperatorToCK3.Mappers.Region.ImperatorRegionMapper(), new ImperatorToCK3.Mappers.Region.CK3RegionMapper());
+			cultureMapper.LoadRegionMappers(new ImperatorRegionMapper(), new CK3RegionMapper());
 
 			var character1 = builder
 				.WithImperatorCharacter(imperatorCharacter1)

--- a/ImperatorToCK3.UnitTests/Imperator/Countries/CountryTests.cs
+++ b/ImperatorToCK3.UnitTests/Imperator/Countries/CountryTests.cs
@@ -95,7 +95,18 @@ namespace ImperatorToCK3.UnitTests.Imperator.Countries {
 		}
 
 		[Fact]
-		public void OriginCountyCanBeRecursive() {
+		public void OriginCountryWithSameIdDoesNotCauseInfiniteLoop() {
+			var reader = new BufferedReader(
+				" = {\n" +
+				"\ttag=\"AAA\"" +
+				"\torigin=42" +
+				"}\n"
+			);
+			var country = Country.Parse(reader, 42);
+			Assert.Equal((ulong)42, country.OriginCountry.Id);
+		}
+		[Fact]
+		public void OriginCountryCanBeRecursive() {
 			var countriesReader = new BufferedReader(
 				"1 = {\n" +
 				"\ttag=\"AAA\"" +
@@ -106,7 +117,7 @@ namespace ImperatorToCK3.UnitTests.Imperator.Countries {
 				"}\n" +
 				"3 = {\n" +
 				"\ttag=\"CCC\"" +
-				"\torigin=3" +
+				"\torigin=2" +
 				"}\n" +
 				"4 = {\n" +
 				"\ttag=\"DDD\"" +

--- a/ImperatorToCK3.UnitTests/Mappers/Culture/CultureMapperTests.cs
+++ b/ImperatorToCK3.UnitTests/Mappers/Culture/CultureMapperTests.cs
@@ -13,7 +13,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.Match("nonMatchingCulture", "", 56, 49, "e_title"));
+			Assert.Null(culMapper.Match("nonMatchingCulture", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -23,7 +23,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.Match("test", "", 56, 49, "e_title"));
+			Assert.Equal("culture", culMapper.Match("test", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -33,7 +33,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.Match("test", "", 56, 49, "e_title"));
+			Assert.Equal("culture", culMapper.Match("test", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -43,7 +43,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.Match("test", "thereligion", 56, 49, "e_title"));
+			Assert.Equal("culture", culMapper.Match("test", "thereligion", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -53,7 +53,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.Match("test", "unreligion", 56, 49, "e_title"));
+			Assert.Null(culMapper.Match("test", "unreligion", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -63,7 +63,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.Match("test", "", 56, 49, "e_title"));
+			Assert.Null(culMapper.Match("test", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -73,7 +73,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.Match("test", "thereligion", 4, 49, "e_title"));
+			Assert.Equal("culture", culMapper.Match("test", "thereligion", 4, 49, "ROM"));
 		}
 
 		[Fact]
@@ -83,31 +83,31 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.Match("test", "thereligion", 3, 49, "e_title"));
+			Assert.Null(culMapper.Match("test", "thereligion", 3, 49, "ROM"));
 		}
 
 		[Fact]
-		public void CultureMatchesWithOwnerTitle() {
+		public void CultureMatchesWithHistoricalTag() {
 			var reader = new BufferedReader(
-				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 owner = e_roman_empire }"
+				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 tag = ROM }"
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.Match("test", "thereligion", 4, 49, "e_roman_empire"));
+			Assert.Equal("culture", culMapper.Match("test", "thereligion", 4, 49, "ROM"));
 		}
 
 		[Fact]
-		public void CultureFailsWithWrongOwnerTitle() {
+		public void CultureFailsWithWrongHistoricalTag() {
 			var reader = new BufferedReader(
-				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 owner = e_roman_empire }"
+				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 tag = ROM }"
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.Match("test", "thereligion", 4, 49, "e_reman_empire"));
+			Assert.Null(culMapper.Match("test", "thereligion", 4, 49, "WRO"));
 		}
 
 		[Fact]
-		public void CultureMatchesWithNoOwnerTitle() {
+		public void CultureMatchesWithNoHistoricalTag() {
 			var reader = new BufferedReader(
 				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 }"
 			);
@@ -117,19 +117,19 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 		}
 
 		[Fact]
-		public void CultureMatchesWithNoOwnerTitleInRule() {
+		public void CultureMatchesWithNoHistoricalTagInRule() {
 			var reader = new BufferedReader(
 				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4}"
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.Match("test", "thereligion", 4, 49, "e_roman_empire"));
+			Assert.Equal("culture", culMapper.Match("test", "thereligion", 4, 49, "ROM"));
 		}
 
 		[Fact]
-		public void CultureFailsWithOwnerTitleInRule() {
+		public void CultureFailsWithHistoricalTagInRule() {
 			var reader = new BufferedReader(
-				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 owner = e_roman_empire }"
+				"link = { ck3 = culture imp = qwe imp = test imp = poi religion = thereligion ck3Province = 4 tag = ROM }"
 			);
 			var culMapper = new CultureMapper(reader);
 
@@ -143,7 +143,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.NonReligiousMatch("nonMatchingCulture", "", 56, 49, "e_title"));
+			Assert.Null(culMapper.NonReligiousMatch("nonMatchingCulture", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -153,7 +153,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.NonReligiousMatch("test", "", 56, 49, "e_title"));
+			Assert.Equal("culture", culMapper.NonReligiousMatch("test", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -163,7 +163,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.NonReligiousMatch("test", "", 56, 49, "e_title"));
+			Assert.Equal("culture", culMapper.NonReligiousMatch("test", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -173,7 +173,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.NonReligiousMatch("test", "thereligion", 56, 49, "e_title"));
+			Assert.Null(culMapper.NonReligiousMatch("test", "thereligion", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -183,7 +183,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.NonReligiousMatch("test", "unreligion", 56, 49, "e_title"));
+			Assert.Null(culMapper.NonReligiousMatch("test", "unreligion", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -193,7 +193,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Null(culMapper.NonReligiousMatch("test", "", 56, 49, "e_title"));
+			Assert.Null(culMapper.NonReligiousMatch("test", "", 56, 49, "ROM"));
 		}
 
 		[Fact]
@@ -203,7 +203,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Culture {
 			);
 			var culMapper = new CultureMapper(reader);
 
-			Assert.Equal("culture", culMapper.NonReligiousMatch("test", "thereligion", 56, 49, "e_title"));
+			Assert.Equal("culture", culMapper.NonReligiousMatch("test", "thereligion", 56, 49, "ROM"));
 		}
 
 		[Fact]

--- a/ImperatorToCK3/CK3/Characters/Character.cs
+++ b/ImperatorToCK3/CK3/Characters/Character.cs
@@ -76,16 +76,11 @@ namespace ImperatorToCK3.CK3.Characters {
 			ulong impProvince = 0;
 			var srcReligion = preImperatorRuler.Religion ?? imperatorCountry.Religion;
 			var srcCulture = preImperatorRuler.Culture ?? imperatorCountry.PrimaryCulture;
-			var ck3TitleNameForMappers = string.Empty;
 			if (imperatorCountry.Capital is not null) {
 				impProvince = (ulong)imperatorCountry.Capital;
 				var ck3Provinces = provinceMapper.GetCK3ProvinceNumbers(impProvince);
 				if (ck3Provinces.Count > 0) {
 					ck3Province = ck3Provinces[0];
-				}
-
-				if (imperatorCountry.CK3Title is not null) {
-					ck3TitleNameForMappers = imperatorCountry.CK3Title.Id;
 				}
 			}
 
@@ -97,7 +92,7 @@ namespace ImperatorToCK3.CK3.Characters {
 			}
 
 			if (srcCulture is not null) {
-				var cultureMatch = cultureMapper.Match(srcCulture, Religion, ck3Province, impProvince, ck3TitleNameForMappers);
+				var cultureMatch = cultureMapper.Match(srcCulture, Religion, ck3Province, impProvince, imperatorCountry.HistoricalTag);
 				if (cultureMatch is not null) {
 					Culture = cultureMatch;
 				}
@@ -175,16 +170,11 @@ namespace ImperatorToCK3.CK3.Characters {
 				Religion = match;
 			}
 
-			var ck3Owner = "";
-			var imperatorCountry = ImperatorCharacter.Country;
-			if (imperatorCountry?.CK3Title is not null) {
-				ck3Owner = imperatorCountry.CK3Title.Id;
-			}
 			match = cultureMapper.Match(
 				ImperatorCharacter.Culture,
 				Religion, ck3Province,
 				ImperatorCharacter.ProvinceId,
-				ck3Owner
+				ImperatorCharacter.Country?.HistoricalTag ?? string.Empty
 			);
 			if (match is null) {
 				Logger.Warn($"Could not determine CK3 culture for Imperator character {ImperatorCharacter.Id}" +

--- a/ImperatorToCK3/CK3/Characters/Character.cs
+++ b/ImperatorToCK3/CK3/Characters/Character.cs
@@ -187,7 +187,7 @@ namespace ImperatorToCK3.CK3.Characters {
 				ck3Owner
 			);
 			if (match is null) {
-				Logger.Warn($"Could not determine CK3 culture for Imperator character {ImperatorCharacter}" +
+				Logger.Warn($"Could not determine CK3 culture for Imperator character {ImperatorCharacter.Id}" +
 							$" with culture {ImperatorCharacter.Culture}!");
 			} else {
 				Culture = match;

--- a/ImperatorToCK3/CK3/Provinces/Province.cs
+++ b/ImperatorToCK3/CK3/Provinces/Province.cs
@@ -108,11 +108,6 @@ public class Province : IIdentifiable<ulong> {
 		}
 	}
 	private void SetCultureFromImperator(CultureMapper cultureMapper) {
-		string ownerTitleName = string.Empty;
-		if (ownerTitle is not null) {
-			ownerTitleName = ownerTitle.Id;
-		}
-
 		var cultureSet = false;
 		if (ImperatorProvince is null) {
 			Logger.Warn($"CK3 Province {Id}: can't set culture from null Imperator Province!");
@@ -121,7 +116,7 @@ public class Province : IIdentifiable<ulong> {
 
 		// do we even have a base culture?
 		if (!string.IsNullOrEmpty(ImperatorProvince.Culture)) {
-			var cultureMatch = cultureMapper.Match(ImperatorProvince.Culture, details.Religion, Id, ImperatorProvince.Id, ownerTitleName);
+			var cultureMatch = cultureMapper.Match(ImperatorProvince.Culture, details.Religion, Id, ImperatorProvince.Id, ImperatorProvince.OwnerCountry?.HistoricalTag ?? string.Empty);
 			if (cultureMatch is not null) {
 				details.Culture = cultureMatch;
 				cultureSet = true;
@@ -129,7 +124,7 @@ public class Province : IIdentifiable<ulong> {
 		}
 		// As fallback, attempt to use primary culture of country.
 		if (!cultureSet && ImperatorProvince.OwnerCountry?.PrimaryCulture is not null) {
-			var cultureMatch = cultureMapper.Match(ImperatorProvince.OwnerCountry.PrimaryCulture, details.Religion, Id, ImperatorProvince.Id, ownerTitleName);
+			var cultureMatch = cultureMapper.Match(ImperatorProvince.OwnerCountry.PrimaryCulture, details.Religion, Id, ImperatorProvince.Id, ImperatorProvince.OwnerCountry?.HistoricalTag ?? string.Empty);
 			if (cultureMatch is not null) {
 				Logger.Warn($"Using country culture for province {Id}");
 				details.Culture = cultureMatch;

--- a/ImperatorToCK3/Data_Files/configurables/culture_map.txt
+++ b/ImperatorToCK3/Data_Files/configurables/culture_map.txt
@@ -4,21 +4,21 @@
 
 # Usage:
 # link = {
-#	ck3 = ck3Culture
-#	imp = impCulture
-#	owner = ck3Title (optional)
-#	religion = ck3Religion (optional)
-#	impProvince = impProvince (optional)
-#	ck3Province = ck3Province (optional)
-#	impRegion = impRegion (optional)
-#	ck3Region = ck3Region (optional)
+#	ck3 = <CK3 culture>
+#	imp = <Imperator culture>
+#	owner = <CK3 title> (optional)
+#	religion = <CK3 religion> (optional)
+#	impProvince = <Imperator province> (optional)
+#	ck3Province = <CK3 province> (optional)
+#	impRegion = <Imperator region> (optional)
+#	ck3Region = <CK3 region> (optional)
 #}
 # multiple entries allowed for: imp, impProvince, ck3Province, impRegion, ck3Region, owner
 # multiple entries not allowed for: ck3
 
-# Variables
-# Use them to avoid duplicating long conditions
-# A variable must be defined BEFORE it's used in a link
+# Variables:
+# Use them to avoid duplicating long conditions.
+# A variable must be defined BEFORE it's used in a link.
 # For example:
 # Instead of:
 # link = { ck3=belgae imp=sennonian imp=bellovacian imp=veliocassian imp=morinian impProvince=1}

--- a/ImperatorToCK3/Data_Files/configurables/culture_map.txt
+++ b/ImperatorToCK3/Data_Files/configurables/culture_map.txt
@@ -6,14 +6,14 @@
 # link = {
 #	ck3 = <CK3 culture>
 #	imp = <Imperator culture>
-#	owner = <CK3 title> (optional)
+#	tag = <historical Imperator tag> (optional)
 #	religion = <CK3 religion> (optional)
 #	impProvince = <Imperator province> (optional)
 #	ck3Province = <CK3 province> (optional)
 #	impRegion = <Imperator region> (optional)
 #	ck3Region = <CK3 region> (optional)
 #}
-# multiple entries allowed for: imp, impProvince, ck3Province, impRegion, ck3Region, owner
+# multiple entries allowed for: imp, impProvince, ck3Province, impRegion, ck3Region, tag
 # multiple entries not allowed for: ck3
 
 # Variables:
@@ -174,7 +174,7 @@ link = { ck3 = thracian imp = triballoi imp = moesi imp = odrysi imp = paeonian 
 
 ## East Levantine
 link = { ck3 = assyrian imp = assyrian }
-link = { ck3 = hebrew imp = aramaic owner = k_israel } # Historical assimilation
+link = { ck3 = hebrew imp = aramaic tag=JUD } # Historical assimilation
 link = { ck3 = aramaic imp = aramaic }
 link = { ck3 = babylonian imp = babylonian }
 
@@ -253,15 +253,9 @@ link = { ck3 = old_saxon @imp_ingvaeonic_cultures } # fallback for Ingvaeonic cu
 link = { ck3 = frankish @imp_frankish_cultures }
 # Irminonic mappings
 link = { ck3 = suebi @imp_suebian_cultures }
+link = { ck3 = langobard @imp_irminonic_cultures tag=LGB }
 link = { ck3 = swabian @imp_irminonic_cultures ck3Province = 2055 ck3Province = 2053 ck3Province = 2051 ck3Province = 2721 ck3Province = 2751 ck3Province = 2717 ck3Province = 2057 ck3Province = 2768 ck3Province = 2773 ck3Province = 2748 ck3Province = 2746 ck3Province = 2763 ck3Province = 2759 ck3Province = 2757 ck3Province = 2778 ck3Province = 2782 ck3Province = 2783 ck3Province = 2786 ck3Province = 2777 ck3Province = 2778 ck3Province = 2782 ck3Province = 2783 ck3Province = 2786 ck3Province = 2777 ck3Province = 2046 ck3Province = 2049 ck3Province = 2460 }
 link = { ck3 = bavarian @imp_irminonic_cultures ck3Province = 2964 ck3Province = 2945 ck3Province = 2949 ck3Province = 2942 ck3Province = 2957 ck3Province = 2959 ck3Province = 2956 ck3Province = 2883 ck3Province = 2960 ck3Province = 2878 ck3Province = 2990 ck3Province = 2987 ck3Province = 2989 ck3Province = 2975 ck3Province = 2977 ck3Province = 3135 ck3Province = 3131 ck3Province = 2971 ck3Province = 3117 ck3Province = 3092 ck3Province = 3109 ck3Province = 3121 ck3Province = 3086 ck3Province = 3081 ck3Province = 3089 ck3Province = 3073 ck3Province = 3093 ck3Province = 3088 ck3Province = 2950 ck3Province = 2955 ck3Province = 3134 ck3Province = 3105 ck3Province = 3128 ck3Province = 3125 ck3Province = 3099 }
-link = { ck3 = langobard @imp_irminonic_cultures
-	ck3Region=custom_hungary ck3Region=custom_core_austria ck3Region=d_bohemia ck3Region=d_moravia 
-}
-link = { ck3 = langobard @imp_irminonic_cultures
-	@culture_splitting_region_I @culture_splitting_region_J
-	@culture_splitting_region_P @culture_splitting_region_Q @culture_splitting_region_S
-}
 link = { ck3 = suebi @imp_irminonic_cultures } # fallback for Irminonic cultures
 
 # Norse mappings
@@ -323,7 +317,7 @@ link = { ck3 = telugu imp = andhran imp = assaka }
 
 ## Latin
 # The Glory of Rome
-link = { ck3 = roman imp = roman imp = osco_umbrian imp = umbrian imp = samnite imp = venetic imp = ligurian imp = lucanian imp = bruttian imp = sardonian imp = siculian owner = e_roman_empire }
+link = { ck3 = roman imp = roman imp = osco_umbrian imp = umbrian imp = samnite imp = venetic imp = ligurian imp = lucanian imp = bruttian imp = sardonian imp = siculian tag=ROM }
 
 # Splitting according to regions
 link = { ck3 = breathanach imp = roman imp = osco_umbrian imp = umbrian imp = samnite imp = venetic imp = ligurian imp = lucanian imp = bruttian imp = sardonian imp = siculian @culture_splitting_region_A }

--- a/ImperatorToCK3/Imperator/Countries/Country.cs
+++ b/ImperatorToCK3/Imperator/Countries/Country.cs
@@ -113,7 +113,7 @@ namespace ImperatorToCK3.Imperator.Countries {
 
 		private ulong? parsedOriginCountryId = null;
 		private Country? originCountry = null;
-		public Country? OriginCountry {
+		public Country OriginCountry {
 			get {
 				var countyToReturn = this;
 				while (countyToReturn.originCountry is not null) {

--- a/ImperatorToCK3/Imperator/Countries/Country.cs
+++ b/ImperatorToCK3/Imperator/Countries/Country.cs
@@ -19,7 +19,12 @@ namespace ImperatorToCK3.Imperator.Countries {
 		public List<RulerTerm> RulerTerms { get; set; } = new();
 		public Dictionary<string, int> HistoricalRegnalNumbers { get; private set; } = new();
 		public string Tag { get; private set; } = "";
-		public string HistoricalTag { get; private set; } = "";
+		private string? historicalTag;
+		public string HistoricalTag {
+			get => historicalTag ?? Tag;
+			private set => historicalTag = value;
+		}
+
 		public string Name => CountryName.Name;
 		public CountryName CountryName { get; private set; } = new();
 		public string Flag { get; private set; } = "";

--- a/ImperatorToCK3/Imperator/Countries/Country.cs
+++ b/ImperatorToCK3/Imperator/Countries/Country.cs
@@ -97,6 +97,9 @@ namespace ImperatorToCK3.Imperator.Countries {
 			}
 
 			var countryId = (ulong)parsedOriginCountryId;
+			if (countryId == Id) {
+				return false;
+			}
 			if (countries.TryGetValue(countryId, out var countryToLink)) {
 				originCountry = countryToLink;
 				return true;

--- a/ImperatorToCK3/Imperator/Countries/Country.cs
+++ b/ImperatorToCK3/Imperator/Countries/Country.cs
@@ -19,6 +19,7 @@ namespace ImperatorToCK3.Imperator.Countries {
 		public List<RulerTerm> RulerTerms { get; set; } = new();
 		public Dictionary<string, int> HistoricalRegnalNumbers { get; private set; } = new();
 		public string Tag { get; private set; } = "";
+		public string HistoricalTag { get; private set; } = "";
 		public string Name => CountryName.Name;
 		public CountryName CountryName { get; private set; } = new();
 		public string Flag { get; private set; } = "";
@@ -90,40 +91,9 @@ namespace ImperatorToCK3.Imperator.Countries {
 			return counter;
 		}
 
-		// Returns whether an origin country was linked to the country
-		public bool LinkCountries(CountryCollection countries, SortedSet<ulong> idsWithoutDefinition) {
-			if (parsedOriginCountryId is null) {
-				return false;
-			}
-
-			var countryId = (ulong)parsedOriginCountryId;
-			if (countryId == Id) {
-				return false;
-			}
-			if (countries.TryGetValue(countryId, out var countryToLink)) {
-				originCountry = countryToLink;
-				return true;
-			}
-			idsWithoutDefinition.Add(countryId);
-			return false;
-		}
-
 		public void TryLinkMonarch(Character character) {
 			if (monarchId == character.Id) {
 				Monarch = character;
-			}
-		}
-
-		private ulong? parsedOriginCountryId = null;
-		private Country? originCountry = null;
-		public Country OriginCountry {
-			get {
-				var countyToReturn = this;
-				while (countyToReturn.originCountry is not null) {
-					countyToReturn = countyToReturn.originCountry;
-				}
-
-				return countyToReturn;
 			}
 		}
 	}

--- a/ImperatorToCK3/Imperator/Countries/Country.cs
+++ b/ImperatorToCK3/Imperator/Countries/Country.cs
@@ -90,9 +90,37 @@ namespace ImperatorToCK3.Imperator.Countries {
 			return counter;
 		}
 
+		// Returns whether an origin country was linked to the country
+		public bool LinkCountries(CountryCollection countries, SortedSet<ulong> idsWithoutDefinition) {
+			if (parsedOriginCountryId is null) {
+				return false;
+			}
+
+			var countryId = (ulong)parsedOriginCountryId;
+			if (countries.TryGetValue(countryId, out var countryToLink)) {
+				originCountry = countryToLink;
+				return true;
+			}
+			idsWithoutDefinition.Add(countryId);
+			return false;
+		}
+
 		public void TryLinkMonarch(Character character) {
 			if (monarchId == character.Id) {
 				Monarch = character;
+			}
+		}
+
+		private ulong? parsedOriginCountryId = null;
+		private Country? originCountry = null;
+		public Country? OriginCountry {
+			get {
+				var countyToReturn = this;
+				while (countyToReturn.originCountry is not null) {
+					countyToReturn = countyToReturn.originCountry;
+				}
+
+				return countyToReturn;
 			}
 		}
 	}

--- a/ImperatorToCK3/Imperator/Countries/CountryCollection.cs
+++ b/ImperatorToCK3/Imperator/Countries/CountryCollection.cs
@@ -32,7 +32,7 @@ namespace ImperatorToCK3.Imperator.Countries {
 
 			Logger.Info($"{counter} families linked to countries.");
 		}
-		private void LinkCountries() {
+		public void LinkCountries() {
 			SortedSet<ulong> idsWithoutDefinition = new();
 			var counter = this.Count(country => country.LinkCountries(this, idsWithoutDefinition));
 

--- a/ImperatorToCK3/Imperator/Countries/CountryCollection.cs
+++ b/ImperatorToCK3/Imperator/Countries/CountryCollection.cs
@@ -11,9 +11,6 @@ namespace ImperatorToCK3.Imperator.Countries {
 			var parser = new Parser();
 			RegisterKeys(parser);
 			parser.ParseStream(reader);
-
-			Logger.Info("Linking Countries with Countries...");
-			LinkCountries();
 		}
 		private void RegisterKeys(Parser parser) {
 			parser.RegisterRegex(CommonRegexes.Integer, (reader, countryId) => {
@@ -31,16 +28,6 @@ namespace ImperatorToCK3.Imperator.Countries {
 			}
 
 			Logger.Info($"{counter} families linked to countries.");
-		}
-		public void LinkCountries() {
-			SortedSet<ulong> idsWithoutDefinition = new();
-			var counter = this.Count(country => country.LinkCountries(this, idsWithoutDefinition));
-
-			if (idsWithoutDefinition.Count > 0) {
-				Logger.Debug($"Countries without definition: {string.Join(", ", idsWithoutDefinition)}");
-			}
-
-			Logger.Info($"{counter} countries linked to countries.");
 		}
 
 		public static CountryCollection ParseBloc(BufferedReader reader) {

--- a/ImperatorToCK3/Imperator/Countries/CountryCollection.cs
+++ b/ImperatorToCK3/Imperator/Countries/CountryCollection.cs
@@ -11,6 +11,9 @@ namespace ImperatorToCK3.Imperator.Countries {
 			var parser = new Parser();
 			RegisterKeys(parser);
 			parser.ParseStream(reader);
+
+			Logger.Info("Linking Countries with Countries...");
+			LinkCountries();
 		}
 		private void RegisterKeys(Parser parser) {
 			parser.RegisterRegex(CommonRegexes.Integer, (reader, countryId) => {
@@ -29,6 +32,17 @@ namespace ImperatorToCK3.Imperator.Countries {
 
 			Logger.Info($"{counter} families linked to countries.");
 		}
+		private void LinkCountries() {
+			SortedSet<ulong> idsWithoutDefinition = new();
+			var counter = this.Count(country => country.LinkCountries(this, idsWithoutDefinition));
+
+			if (idsWithoutDefinition.Count > 0) {
+				Logger.Debug($"Countries without definition: {string.Join(", ", idsWithoutDefinition)}");
+			}
+
+			Logger.Info($"{counter} countries linked to countries.");
+		}
+
 		public static CountryCollection ParseBloc(BufferedReader reader) {
 			var blocParser = new Parser();
 			CountryCollection countries = new();

--- a/ImperatorToCK3/Imperator/Countries/CountryFactory.cs
+++ b/ImperatorToCK3/Imperator/Countries/CountryFactory.cs
@@ -20,6 +20,7 @@ namespace ImperatorToCK3.Imperator.Countries {
 
 		static Country() {
 			parser.RegisterKeyword("tag", reader => parsedCountry.Tag = reader.GetString());
+			parser.RegisterKeyword("origin", reader => parsedCountry.parsedOriginCountryId = reader.GetULong());
 			parser.RegisterKeyword("country_name", reader => parsedCountry.CountryName = CountryName.Parse(reader));
 			parser.RegisterKeyword("flag", reader => parsedCountry.Flag = reader.GetString());
 			parser.RegisterKeyword("country_type", reader => {

--- a/ImperatorToCK3/Imperator/Countries/CountryFactory.cs
+++ b/ImperatorToCK3/Imperator/Countries/CountryFactory.cs
@@ -20,7 +20,7 @@ namespace ImperatorToCK3.Imperator.Countries {
 
 		static Country() {
 			parser.RegisterKeyword("tag", reader => parsedCountry.Tag = reader.GetString());
-			parser.RegisterKeyword("origin", reader => parsedCountry.parsedOriginCountryId = reader.GetULong());
+			parser.RegisterKeyword("historical", reader => parsedCountry.HistoricalTag = reader.GetString());
 			parser.RegisterKeyword("country_name", reader => parsedCountry.CountryName = CountryName.Parse(reader));
 			parser.RegisterKeyword("flag", reader => parsedCountry.Flag = reader.GetString());
 			parser.RegisterKeyword("country_type", reader => {

--- a/ImperatorToCK3/Imperator/World.cs
+++ b/ImperatorToCK3/Imperator/World.cs
@@ -137,16 +137,16 @@ namespace ImperatorToCK3.Imperator {
 			Logger.Info("*** Building World ***");
 
 			// Link all the intertwining references
-			Logger.Info("Linking Characters with Families");
+			Logger.Info("Linking Characters with Families...");
 			Characters.LinkFamilies(Families);
 			Families.RemoveUnlinkedMembers();
-			Logger.Info("Linking Characters with Countries");
+			Logger.Info("Linking Characters with Countries...");
 			Characters.LinkCountries(Countries);
-			Logger.Info("Linking Provinces with Pops");
+			Logger.Info("Linking Provinces with Pops...");
 			Provinces.LinkPops(pops);
-			Logger.Info("Linking Provinces with Countries");
+			Logger.Info("Linking Provinces with Countries...");
 			Provinces.LinkCountries(Countries);
-			Logger.Info("Linking Countries with Families");
+			Logger.Info("Linking Countries with Families...");
 			Countries.LinkFamilies(Families);
 
 			LoadPreImperatorRulers();

--- a/ImperatorToCK3/Mappers/Culture/CultureMapper.cs
+++ b/ImperatorToCK3/Mappers/Culture/CultureMapper.cs
@@ -34,10 +34,10 @@ public class CultureMapper {
 		string ck3Religion,
 		ulong ck3ProvinceId,
 		ulong impProvinceId,
-		string ck3OwnerTitle
+		string historicalTag
 	) {
 		foreach (var cultureMappingRule in cultureMappingRules) {
-			var possibleMatch = cultureMappingRule.Match(impCulture, ck3Religion, ck3ProvinceId, impProvinceId, ck3OwnerTitle);
+			var possibleMatch = cultureMappingRule.Match(impCulture, ck3Religion, ck3ProvinceId, impProvinceId, historicalTag);
 			if (possibleMatch is not null) {
 				return possibleMatch;
 			}
@@ -50,10 +50,10 @@ public class CultureMapper {
 		string ck3Religion,
 		ulong ck3ProvinceId,
 		ulong impProvinceId,
-		string ck3OwnerTitle
+		string historicalTag
 	) {
 		foreach (var cultureMappingRule in cultureMappingRules) {
-			var possibleMatch = cultureMappingRule.NonReligiousMatch(impCulture, ck3Religion, ck3ProvinceId, impProvinceId, ck3OwnerTitle);
+			var possibleMatch = cultureMappingRule.NonReligiousMatch(impCulture, ck3Religion, ck3ProvinceId, impProvinceId, historicalTag);
 			if (possibleMatch is not null) {
 				return possibleMatch;
 			}

--- a/ImperatorToCK3/Mappers/Culture/CultureMappingRule.cs
+++ b/ImperatorToCK3/Mappers/Culture/CultureMappingRule.cs
@@ -19,7 +19,7 @@ public class CultureMappingRule {
 		string ck3Religion,
 		ulong ck3ProvinceId,
 		ulong impProvinceId,
-		string ck3OwnerTitle
+		string historicalTag
 	) {
 		// We need at least a viable impCulture.
 		if (string.IsNullOrEmpty(impCulture)) {
@@ -30,8 +30,8 @@ public class CultureMappingRule {
 			return null;
 		}
 
-		if (owners.Count > 0) {
-			if (string.IsNullOrEmpty(ck3OwnerTitle) || !owners.Contains(ck3OwnerTitle)) {
+		if (tags.Count > 0) {
+			if (string.IsNullOrEmpty(historicalTag) || !tags.Contains(historicalTag)) {
 				return null;
 			}
 		}
@@ -92,7 +92,7 @@ public class CultureMappingRule {
 		string ck3Religion,
 		ulong ck3ProvinceId,
 		ulong impProvinceId,
-		string ck3OwnerTitle
+		string historicalTag
 	) {
 		// This is a non religious match. We need a mapping without any religion, so if the
 		// mapping rule has any religious qualifiers it needs to fail.
@@ -101,13 +101,13 @@ public class CultureMappingRule {
 		}
 
 		// Otherwise, as usual.
-		return Match(impCulture, ck3Religion, ck3ProvinceId, impProvinceId, ck3OwnerTitle);
+		return Match(impCulture, ck3Religion, ck3ProvinceId, impProvinceId, historicalTag);
 	}
 
 	private string destinationCulture = string.Empty;
 	private readonly SortedSet<string> cultures = new();
 	private readonly SortedSet<string> religions = new();
-	private readonly SortedSet<string> owners = new();
+	private readonly SortedSet<string> tags = new();
 	private readonly SortedSet<ulong> imperatorProvinces = new();
 	private readonly SortedSet<ulong> ck3Provinces = new();
 	private readonly SortedSet<string> imperatorRegions = new();
@@ -117,7 +117,7 @@ public class CultureMappingRule {
 		parser.RegisterKeyword("ck3", reader => mappingToReturn.destinationCulture = reader.GetString());
 		parser.RegisterKeyword("imp", reader => mappingToReturn.cultures.Add(reader.GetString()));
 		parser.RegisterKeyword("religion", reader => mappingToReturn.religions.Add(reader.GetString()));
-		parser.RegisterKeyword("owner", reader => mappingToReturn.owners.Add(reader.GetString()));
+		parser.RegisterKeyword("tag", reader => mappingToReturn.tags.Add(reader.GetString()));
 		parser.RegisterKeyword("ck3Region", reader => mappingToReturn.ck3Regions.Add(reader.GetString()));
 		parser.RegisterKeyword("impRegion", reader => mappingToReturn.imperatorRegions.Add(reader.GetString()));
 		parser.RegisterKeyword("ck3Province", reader => mappingToReturn.ck3Provinces.Add(reader.GetULong()));


### PR DESCRIPTION
This allows us to make more detailed mappings. For example, Langobards have no separate culture in Imperator, but we are now able to use LGB (Langobardia) tag to make a mapping for them, instead of using a regional mapping.