### PR TITLE
Prevent opposite traits in characters from Imperator

### DIFF
--- a/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
@@ -25,7 +25,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 			private ImperatorToCK3.Imperator.Characters.Character imperatorCharacter = new(0);
 			private ReligionMapper religionMapper = new();
 			private CultureMapper cultureMapper = new(new ImperatorRegionMapper(), new CK3RegionMapper());
-			private TraitMapper traitMapper = new("TestFiles/configurables/trait_map.txt", new Configuration(){CK3Path = "TestFiles/CK3"});
+			private TraitMapper traitMapper = new("TestFiles/configurables/trait_map.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 			private NicknameMapper nicknameMapper = new("TestFiles/configurables/nickname_map.txt");
 			private LocDB locDB = new("english");
 			private ProvinceMapper provinceMapper = new();

--- a/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
@@ -160,8 +160,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 		[Fact]
 		public void TraitsCanBeInitializedFromImperator() {
 			var ck3Traits = new IdObjectCollection<string, Trait> {
-				new Trait("strong"),
-				new Trait("humble"),
+				new Trait("powerful"),
 				new Trait("craven")
 			};
 			var impToCK3TraitDict = new Dictionary<string, string> {

--- a/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Characters/CK3CharacterTests.cs
@@ -1,4 +1,5 @@
 ﻿using commonItems;
+using commonItems.Collections;
 using commonItems.Localization;
 using ImperatorToCK3.CK3.Characters;
 using ImperatorToCK3.CK3.Titles;
@@ -10,9 +11,11 @@ using ImperatorToCK3.Mappers.Region;
 using ImperatorToCK3.Mappers.Religion;
 using ImperatorToCK3.Mappers.Trait;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using ImperatorToCK3.Imperator.Families;
+using ImperatorToCK3.UnitTests.Mappers.Trait;
 
 namespace ImperatorToCK3.UnitTests.CK3.Characters {
 	[Collection("Sequential")]
@@ -22,7 +25,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 			private ImperatorToCK3.Imperator.Characters.Character imperatorCharacter = new(0);
 			private ReligionMapper religionMapper = new();
 			private CultureMapper cultureMapper = new(new ImperatorRegionMapper(), new CK3RegionMapper());
-			private TraitMapper traitMapper = new("TestFiles/configurables/trait_map.txt");
+			private TraitMapper traitMapper = new("TestFiles/configurables/trait_map.txt", new Configuration(){CK3Path = "TestFiles/CK3"});
 			private NicknameMapper nicknameMapper = new("TestFiles/configurables/nickname_map.txt");
 			private LocDB locDB = new("english");
 			private ProvinceMapper provinceMapper = new();
@@ -156,14 +159,20 @@ namespace ImperatorToCK3.UnitTests.CK3.Characters {
 
 		[Fact]
 		public void TraitsCanBeInitializedFromImperator() {
+			var ck3Traits = new IdObjectCollection<string, Trait> {
+				new Trait("strong"),
+				new Trait("humble"),
+				new Trait("craven")
+			};
+			var impToCK3TraitDict = new Dictionary<string, string> {
+				{"strong", "powerful"},
+				{"craven", "craven"}
+			};
+			var traitMapper = new TraitMapperTests.TestTraitMapper(impToCK3TraitDict, ck3Traits);
+
 			var imperatorCharacter = new ImperatorToCK3.Imperator.Characters.Character(1) {
 				Traits = new() { "strong", "humble", "craven" }
 			};
-			var traitMapReader = new BufferedReader(
-				"link = { imp = strong ck3 = powerful } link = { imp = craven ck3 = craven }"
-			);
-			var traitMapper = new TraitMapper(traitMapReader);
-
 			var character = builder
 				.WithImperatorCharacter(imperatorCharacter)
 				.WithTraitMapper(traitMapper)

--- a/ImperatorToCK3.UnitTests/CK3/Characters/TraitTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Characters/TraitTests.cs
@@ -1,0 +1,23 @@
+﻿using commonItems;
+using ImperatorToCK3.CK3.Characters;
+using Xunit;
+
+namespace ImperatorToCK3.UnitTests.CK3.Characters;
+
+public class TraitTests {
+	[Fact]
+	public void OppositesDefaultToEmpty() {
+		var trait = new Trait("dumb");
+		Assert.Empty(trait.Opposites);
+	}
+	[Fact]
+	public void OppositesAreRead() {
+		var reader = new BufferedReader("{ opposites = { wise smart } }");
+		var trait = new Trait("dumb", reader);
+
+		Assert.Collection(trait.Opposites,
+			opposite => Assert.Equal("wise", opposite),
+			opposite => Assert.Equal("smart", opposite)
+		);
+	}
+}

--- a/ImperatorToCK3.UnitTests/CK3/Dynasties/DynastyTests.cs
+++ b/ImperatorToCK3.UnitTests/CK3/Dynasties/DynastyTests.cs
@@ -19,7 +19,7 @@ namespace ImperatorToCK3.UnitTests.CK3.Dynasties {
 			private ImperatorToCK3.Imperator.Characters.Character imperatorCharacter = new(0);
 			private ReligionMapper religionMapper = new();
 			private CultureMapper cultureMapper = new(new ImperatorRegionMapper(), new CK3RegionMapper());
-			private TraitMapper traitMapper = new("TestFiles/configurables/trait_map.txt");
+			private TraitMapper traitMapper = new("TestFiles/configurables/trait_map.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 			private NicknameMapper nicknameMapper = new("TestFiles/configurables/nickname_map.txt");
 			private LocDB locDB = new("english", "french", "german", "russian", "simp_chinese", "spanish");
 			private ProvinceMapper provinceMapper = new();

--- a/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
+++ b/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
@@ -75,7 +75,7 @@ public class TraitMapperTests {
 
 	[Fact]
 	public void OppositeTraitsAreNotReturned() {
-		var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+		var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 
 		// when checked separately, mapper returns both
 		Assert.Equal("wise", mapper.GetCK3TraitForImperatorTrait("wise"));

--- a/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
+++ b/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
@@ -1,66 +1,88 @@
 ﻿using commonItems;
+using commonItems.Collections;
 using ImperatorToCK3.Mappers.Trait;
+using System.Collections.Generic;
 using Xunit;
 
-namespace ImperatorToCK3.UnitTests.Mappers.Trait {
-	public class TraitMapperTests {
-		[Fact]
-		public void NonMatchGivesEmptyOptional() {
-			var reader = new BufferedReader("link = { ck3 = ck3Trait imp = impTrait }");
-			var mapper = new TraitMapper(reader);
+namespace ImperatorToCK3.UnitTests.Mappers.Trait;
 
-			var ck3Trait = mapper.GetCK3TraitForImperatorTrait("nonMatchingTrait");
-			Assert.Null(ck3Trait);
+public class TraitMapperTests {
+	public class TestTraitMapper : TraitMapper {
+		public TestTraitMapper(Dictionary<string, string> impToCK3TraitMap, IdObjectCollection<string, ImperatorToCK3.CK3.Characters.Trait> ck3Traits) : base() {
+			this.ImpToCK3TraitMap = impToCK3TraitMap;
+			this.CK3Traits = ck3Traits;
 		}
+	}
+	[Fact]
+	public void NonMatchGivesEmptyOptional() {
+		var ck3Traits = new IdObjectCollection<string, ImperatorToCK3.CK3.Characters.Trait> {new("ck3Trait")};
+		var traitsDict = new Dictionary<string, string> {{"impTrait", "ck3Trait"}};
+		var mapper = new TestTraitMapper(traitsDict, ck3Traits);
 
-		[Fact]
-		public void Ck3TraitCanBeFound() {
-			var reader = new BufferedReader("link = { ck3 = ck3Trait imp = impTrait }");
-			var mapper = new TraitMapper(reader);
+		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("nonMatchingTrait");
+		Assert.Null(ck3Trait);
+	}
 
-			var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait");
-			Assert.Equal("ck3Trait", ck3Trait);
-		}
+	[Fact]
+	public void Ck3TraitCanBeFound() {
+		var ck3Traits = new IdObjectCollection<string, ImperatorToCK3.CK3.Characters.Trait> { new("ck3Trait") };
+		var traitsDict = new Dictionary<string, string> { { "impTrait", "ck3Trait" } };
+		var mapper = new TestTraitMapper(traitsDict, ck3Traits);
 
-		[Fact]
-		public void MultipleImpTraitsCanBeInARule() {
-			var reader = new BufferedReader("link = { ck3 = ck3Trait imp = impTrait imp = impTrait2 }");
-			var mapper = new TraitMapper(reader);
+		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait");
+		Assert.Equal("ck3Trait", ck3Trait);
+	}
 
-			var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait2");
-			Assert.Equal("ck3Trait", ck3Trait);
-		}
+	[Fact]
+	public void MultipleImpTraitsCanBeInARule() {
+		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_multiple_ck3_in_rule.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
 
-		[Fact]
-		public void CorrectRuleMatches() {
-			var reader = new BufferedReader(
-				"link = { ck3 = ck3Trait imp = impTrait }" +
-				"link = { ck3 = ck3Trait2 imp = impTrait2 }"
-			);
-			var mapper = new TraitMapper(reader);
+		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait2");
+		Assert.Equal("ck3Trait", ck3Trait);
+	}
 
-			var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait2");
-			Assert.Equal("ck3Trait2", ck3Trait);
-		}
+	[Fact]
+	public void CorrectRuleMatches() {
+		var ck3Traits = new IdObjectCollection<string, ImperatorToCK3.CK3.Characters.Trait> { new("ck3Trait"), new("ck3Trait2") };
+		var traitsDict = new Dictionary<string, string> {
+			{ "impTrait", "ck3Trait" },
+			{"impTrait2", "ck3Trait2"}
+		};
+		var mapper = new TestTraitMapper(traitsDict, ck3Traits);
 
-		[Fact]
-		public void MappingsAreReadFromFile() {
-			var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt");
-			Assert.Equal("dull", mapper.GetCK3TraitForImperatorTrait("dull"));
-			Assert.Equal("dull", mapper.GetCK3TraitForImperatorTrait("stupid"));
-			Assert.Equal("kind", mapper.GetCK3TraitForImperatorTrait("friendly"));
-			Assert.Equal("brave", mapper.GetCK3TraitForImperatorTrait("brave"));
-		}
+		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait2");
+		Assert.Equal("ck3Trait2", ck3Trait);
+	}
 
-		[Fact]
-		public void MappingsWithNoCK3TraitAreIgnored() {
-			var reader = new BufferedReader(
-				"link = { imp = impTrait }"
-			);
-			var mapper = new TraitMapper(reader);
+	[Fact]
+	public void MappingsAreReadFromFile() {
+		var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+		Assert.Equal("dull", mapper.GetCK3TraitForImperatorTrait("dull"));
+		Assert.Equal("dull", mapper.GetCK3TraitForImperatorTrait("stupid"));
+		Assert.Equal("kind", mapper.GetCK3TraitForImperatorTrait("friendly"));
+		Assert.Equal("brave", mapper.GetCK3TraitForImperatorTrait("brave"));
+	}
 
-			var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait");
-			Assert.Null(ck3Trait);
-		}
+	[Fact]
+	public void MappingsWithNoCK3TraitAreIgnored() {
+		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_mapping_with_no_ck3.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+
+		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait");
+		Assert.Null(ck3Trait);
+	}
+
+	[Fact]
+	public void OppositeTraitsAreNotReturned() {
+		var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+
+		// when checked separately, mapper returns both
+		Assert.Equal("wise", mapper.GetCK3TraitForImperatorTrait("wise"));
+		Assert.Equal("dumb", mapper.GetCK3TraitForImperatorTrait("dumb"));
+
+		// when mapping a set of traits, opposites are not returned
+		var impTraits = new List<string> { "wise", "dumb" };
+		Assert.Collection(mapper.GetCK3TraitsForImperatorTraits(impTraits),
+			trait => Assert.Equal("wise", trait)
+		);
 	}
 }

--- a/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
+++ b/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
@@ -1,7 +1,9 @@
 ﻿using commonItems;
 using commonItems.Collections;
 using ImperatorToCK3.Mappers.Trait;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace ImperatorToCK3.UnitTests.Mappers.Trait;
@@ -84,5 +86,14 @@ public class TraitMapperTests {
 		Assert.Collection(mapper.GetCK3TraitsForImperatorTraits(impTraits),
 			trait => Assert.Equal("wise", trait)
 		);
+	}
+
+	[Fact]
+	public void WarningIsLoggedWhenMappingContainsUndefinedCK3Trait() {
+		var logWriter = new StringWriter();
+		Console.SetOut(logWriter);
+		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_undefined_ck3_trait.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+
+		Assert.Contains("[WARN] Couldn't find definition for CK3 trait undefined, skipping!", logWriter.ToString());
 	}
 }

--- a/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
+++ b/ImperatorToCK3.UnitTests/Mappers/Trait/TraitMapperTests.cs
@@ -10,7 +10,7 @@ namespace ImperatorToCK3.UnitTests.Mappers.Trait;
 
 public class TraitMapperTests {
 	public class TestTraitMapper : TraitMapper {
-		public TestTraitMapper(Dictionary<string, string> impToCK3TraitMap, IdObjectCollection<string, ImperatorToCK3.CK3.Characters.Trait> ck3Traits) : base() {
+		public TestTraitMapper(Dictionary<string, string> impToCK3TraitMap, IdObjectCollection<string, ImperatorToCK3.CK3.Characters.Trait> ck3Traits) {
 			this.ImpToCK3TraitMap = impToCK3TraitMap;
 			this.CK3Traits = ck3Traits;
 		}
@@ -36,8 +36,8 @@ public class TraitMapperTests {
 	}
 
 	[Fact]
-	public void MultipleImpTraitsCanBeInARule() {
-		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_multiple_ck3_in_rule.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+	public void MultipleImperatorTraitsCanBeInARule() {
+		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_multiple_ck3_in_rule.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 
 		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait2");
 		Assert.Equal("ck3Trait", ck3Trait);
@@ -58,7 +58,7 @@ public class TraitMapperTests {
 
 	[Fact]
 	public void MappingsAreReadFromFile() {
-		var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+		var mapper = new TraitMapper("TestFiles/configurables/trait_map.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 		Assert.Equal("dull", mapper.GetCK3TraitForImperatorTrait("dull"));
 		Assert.Equal("dull", mapper.GetCK3TraitForImperatorTrait("stupid"));
 		Assert.Equal("kind", mapper.GetCK3TraitForImperatorTrait("friendly"));
@@ -67,7 +67,7 @@ public class TraitMapperTests {
 
 	[Fact]
 	public void MappingsWithNoCK3TraitAreIgnored() {
-		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_mapping_with_no_ck3.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_mapping_with_no_ck3.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 
 		var ck3Trait = mapper.GetCK3TraitForImperatorTrait("impTrait");
 		Assert.Null(ck3Trait);
@@ -92,7 +92,7 @@ public class TraitMapperTests {
 	public void WarningIsLoggedWhenMappingContainsUndefinedCK3Trait() {
 		var logWriter = new StringWriter();
 		Console.SetOut(logWriter);
-		var mapper = new TraitMapper("TestFiles/TraitMapperTests/trait_map_undefined_ck3_trait.txt", new Configuration() { CK3Path = "TestFiles/CK3" });
+		_ = new TraitMapper("TestFiles/TraitMapperTests/trait_map_undefined_ck3_trait.txt", new Configuration { CK3Path = "TestFiles/CK3" });
 
 		Assert.Contains("[WARN] Couldn't find definition for CK3 trait undefined, skipping!", logWriter.ToString());
 	}

--- a/ImperatorToCK3.UnitTests/TestFiles/CK3/game/common/traits/test_traits.txt
+++ b/ImperatorToCK3.UnitTests/TestFiles/CK3/game/common/traits/test_traits.txt
@@ -1,0 +1,14 @@
+wise = {
+	opposites = { dumb }
+}
+dumb = {
+	opposites = { wise }
+}
+
+
+dull = {}
+kind = {}
+brave = {}
+
+ck3Trait = {}
+ck3Trait2 = {}

--- a/ImperatorToCK3.UnitTests/TestFiles/TraitMapperTests/trait_map_mapping_with_no_ck3.txt
+++ b/ImperatorToCK3.UnitTests/TestFiles/TraitMapperTests/trait_map_mapping_with_no_ck3.txt
@@ -1,0 +1,1 @@
+link = { imp = impTrait }

--- a/ImperatorToCK3.UnitTests/TestFiles/TraitMapperTests/trait_map_multiple_ck3_in_rule.txt
+++ b/ImperatorToCK3.UnitTests/TestFiles/TraitMapperTests/trait_map_multiple_ck3_in_rule.txt
@@ -1,0 +1,1 @@
+link = { ck3 = ck3Trait imp = impTrait imp = impTrait2 }

--- a/ImperatorToCK3.UnitTests/TestFiles/TraitMapperTests/trait_map_undefined_ck3_trait.txt
+++ b/ImperatorToCK3.UnitTests/TestFiles/TraitMapperTests/trait_map_undefined_ck3_trait.txt
@@ -1,0 +1,1 @@
+link = { ck3 = undefined imp = impTrait }

--- a/ImperatorToCK3.UnitTests/TestFiles/configurables/trait_map.txt
+++ b/ImperatorToCK3.UnitTests/TestFiles/configurables/trait_map.txt
@@ -1,3 +1,6 @@
 ﻿link = { ck3 = dull imp = dull imp = stupid }
 link = { ck3 = kind imp = friendly }
 link = { ck3 = brave imp = brave }
+
+link = { ck3 = wise imp = wise }
+link = { ck3 = dumb imp = dumb }

--- a/ImperatorToCK3/CK3/Characters/Character.cs
+++ b/ImperatorToCK3/CK3/Characters/Character.cs
@@ -191,12 +191,7 @@ namespace ImperatorToCK3.CK3.Characters {
 				Culture = match;
 			}
 
-			foreach (var impTrait in ImperatorCharacter.Traits) {
-				var traitMatch = traitMapper.GetCK3TraitForImperatorTrait(impTrait);
-				if (traitMatch is not null) {
-					Traits.Add(traitMatch);
-				}
-			}
+			Traits.UnionWith(traitMapper.GetCK3TraitsForImperatorTraits(ImperatorCharacter.Traits));
 
 			var nicknameMatch = nicknameMapper.GetCK3NicknameForImperatorNickname(ImperatorCharacter.Nickname);
 			if (nicknameMatch is not null) {

--- a/ImperatorToCK3/CK3/Characters/Trait.cs
+++ b/ImperatorToCK3/CK3/Characters/Trait.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace ImperatorToCK3.CK3.Characters;
 public class Trait : IIdentifiable<string> {
 	public string Id { get; }
-	public ISet<string> Opposites = new HashSet<string>();
+	public ISet<string> Opposites { get; private set; }= new HashSet<string>();
 
 	public Trait(string id) {
 		Id = id;

--- a/ImperatorToCK3/CK3/Characters/Trait.cs
+++ b/ImperatorToCK3/CK3/Characters/Trait.cs
@@ -1,0 +1,22 @@
+﻿using commonItems;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ImperatorToCK3.CK3.Characters {
+	internal class Trait {
+		public string Id { get; }
+		public ISet<string> Opposites = new HashSet<string>();
+
+		public Trait(string id, BufferedReader traitReader) {
+			Id = id;
+
+			var parser = new Parser();
+			parser.RegisterKeyword("opposites", reader => Opposites = reader.GetStrings().ToHashSet());
+			parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);
+			parser.ParseStream(traitReader);
+		}
+	}
+}

--- a/ImperatorToCK3/CK3/Characters/Trait.cs
+++ b/ImperatorToCK3/CK3/Characters/Trait.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace ImperatorToCK3.CK3.Characters;
 public class Trait : IIdentifiable<string> {
 	public string Id { get; }
-	public ISet<string> Opposites { get; private set; }= new HashSet<string>();
+	public ISet<string> Opposites { get; private set; } = new HashSet<string>();
 
 	public Trait(string id) {
 		Id = id;

--- a/ImperatorToCK3/CK3/Characters/Trait.cs
+++ b/ImperatorToCK3/CK3/Characters/Trait.cs
@@ -1,22 +1,20 @@
 ﻿using commonItems;
-using System;
+using commonItems.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace ImperatorToCK3.CK3.Characters {
-	internal class Trait {
-		public string Id { get; }
-		public ISet<string> Opposites = new HashSet<string>();
+namespace ImperatorToCK3.CK3.Characters;
+public class Trait : IIdentifiable<string> {
+	public string Id { get; }
+	public ISet<string> Opposites = new HashSet<string>();
 
-		public Trait(string id, BufferedReader traitReader) {
-			Id = id;
-
-			var parser = new Parser();
-			parser.RegisterKeyword("opposites", reader => Opposites = reader.GetStrings().ToHashSet());
-			parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);
-			parser.ParseStream(traitReader);
-		}
+	public Trait(string id) {
+		Id = id;
+	}
+	public Trait(string id, BufferedReader traitReader) : this(id) {
+		var parser = new Parser();
+		parser.RegisterKeyword("opposites", reader => Opposites = reader.GetStrings().ToHashSet());
+		parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);
+		parser.ParseStream(traitReader);
 	}
 }

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -103,7 +103,7 @@ namespace ImperatorToCK3.CK3 {
 				countyLevelGovernorships
 			);
 
-			traitMapper = new(Path.Combine("configurables", "trait_map.txt"), config);
+			var traitMapper = new TraitMapper(Path.Combine("configurables", "trait_map.txt"), config);
 
 			Characters.ImportImperatorCharacters(
 				impWorld,
@@ -311,7 +311,6 @@ namespace ImperatorToCK3.CK3 {
 			tagTitleMappingsPath: Path.Combine("configurables", "title_map.txt"),
 			governorshipTitleMappingsPath: Path.Combine("configurables", "governorMappings.txt")
 		);
-		private readonly TraitMapper traitMapper;
 		private readonly CK3RegionMapper ck3RegionMapper;
 		private readonly ImperatorRegionMapper imperatorRegionMapper;
 		private readonly TitlesHistory titlesHistory;

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -103,6 +103,8 @@ namespace ImperatorToCK3.CK3 {
 				countyLevelGovernorships
 			);
 
+			traitMapper = new(Path.Combine("configurables", "trait_map.txt"), config);
+
 			Characters.ImportImperatorCharacters(
 				impWorld,
 				religionMapper,
@@ -309,7 +311,7 @@ namespace ImperatorToCK3.CK3 {
 			tagTitleMappingsPath: Path.Combine("configurables", "title_map.txt"),
 			governorshipTitleMappingsPath: Path.Combine("configurables", "governorMappings.txt")
 		);
-		private readonly TraitMapper traitMapper = new(Path.Combine("configurables", "trait_map.txt"));
+		private readonly TraitMapper traitMapper;
 		private readonly CK3RegionMapper ck3RegionMapper;
 		private readonly ImperatorRegionMapper imperatorRegionMapper;
 		private readonly TitlesHistory titlesHistory;

--- a/ImperatorToCK3/Mappers/Trait/TraitMapper.cs
+++ b/ImperatorToCK3/Mappers/Trait/TraitMapper.cs
@@ -1,24 +1,27 @@
 ﻿using commonItems;
+using commonItems.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ImperatorToCK3.Mappers.Trait;
 
 public class TraitMapper {
-	private readonly Dictionary<string, string> impToCK3TraitMap = new();
+	protected Dictionary<string, string> ImpToCK3TraitMap = new();
+	protected IdObjectCollection<string, CK3.Characters.Trait> CK3Traits = new();
 
 	public TraitMapper() { }
-	public TraitMapper(string filePath) {
+	public TraitMapper(string mappingsPath, Configuration config) {
+		var traitsParser = new Parser();
+		traitsParser.RegisterRegex(CommonRegexes.String, (reader, traitId) => CK3Traits.AddOrReplace(new(traitId, reader)));
+		traitsParser.ParseGameFolder("common/traits", config.CK3Path, "txt", new List<Mod>(), true);
+
 		Logger.Info("Parsing trait mappings...");
 		var parser = new Parser();
 		RegisterKeys(parser);
-		parser.ParseFile(filePath);
-		Logger.Info($"Loaded {impToCK3TraitMap.Count} trait links.");
+		parser.ParseFile(mappingsPath);
+		Logger.Info($"Loaded {ImpToCK3TraitMap.Count} trait links.");
 	}
-	public TraitMapper(BufferedReader reader) {
-		var parser = new Parser();
-		RegisterKeys(parser);
-		parser.ParseStream(reader);
-	}
+
 	private void RegisterKeys(Parser parser) {
 		parser.RegisterKeyword("link", reader => {
 			var mapping = new TraitMapping(reader);
@@ -26,12 +29,36 @@ public class TraitMapper {
 				return;
 			}
 			foreach (var imperatorTrait in mapping.ImpTraits) {
-				impToCK3TraitMap.Add(imperatorTrait, mapping.CK3Trait);
+				var ck3TraitId = mapping.CK3Trait;
+				if (!CK3Traits.ContainsKey(ck3TraitId)) {
+					Logger.Warn($"Couldn't find definition for CK3 trait {ck3TraitId}, skipping!");
+					continue;
+				}
+				ImpToCK3TraitMap.Add(imperatorTrait, ck3TraitId);
 			}
 		});
 		parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreAndLogItem);
 	}
 	public string? GetCK3TraitForImperatorTrait(string impTrait) {
-		return impToCK3TraitMap.TryGetValue(impTrait, out var ck3Trait) ? ck3Trait : null;
+		return ImpToCK3TraitMap.TryGetValue(impTrait, out var ck3Trait) ? ck3Trait : null;
+	}
+	public ISet<string> GetCK3TraitsForImperatorTraits(IEnumerable<string> impTraits) {
+		ISet<string> ck3TraitsToReturn = new HashSet<string>();
+		foreach (var impTrait in impTraits) {
+			var ck3Trait = GetCK3TraitForImperatorTrait(impTrait);
+			if (ck3Trait is null) {
+				continue;
+			}
+			ck3TraitsToReturn.Add(ck3Trait);
+		}
+
+		// Remove opposite traits to prevent CK3 log errors
+		foreach (var ck3TraitId in ck3TraitsToReturn.ToList()) {
+			if (!ck3TraitsToReturn.Contains(ck3TraitId)) {
+				continue;
+			}
+			ck3TraitsToReturn = ck3TraitsToReturn.Except(CK3Traits[ck3TraitId].Opposites).ToHashSet();
+		}
+		return ck3TraitsToReturn;
 	}
 }


### PR DESCRIPTION
Prevents characters from having for example both `cynical` and `zealous` traits.
Should slightly improve CK3 load time #677.