### PR TITLE
Convert more holding owners to title holders

### DIFF
--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -492,6 +492,19 @@ public partial class Title {
 					continue;
 				}
 				
+				var realm = ck3Owner.ImperatorCharacter?.HomeCountry?.CK3Title;
+				var deFactoLiege = realm;
+				if (realm is not null) {
+					var deJureDuchy = barony.DeJureLiege?.DeJureLiege;
+					if (deJureDuchy is not null && deJureDuchy.GetHolderId(conversionDate) != "0" && deJureDuchy.GetTopRealm(conversionDate) == realm) {
+						deFactoLiege = deJureDuchy;
+					} else {
+						var deJureKingdom = deJureDuchy?.DeJureLiege;
+						if (deJureKingdom is not null && deJureKingdom.GetHolderId(conversionDate) != "0" && deJureKingdom.GetTopRealm(conversionDate) == realm) {
+							deFactoLiege = deJureKingdom;
+						}
+					}
+				}
 				if (countyCapitalBaronies.Contains(barony)) {
 					// If barony is a county capital, set the county holder to the holding owner.
 					var county = barony.DeJureLiege;
@@ -500,8 +513,11 @@ public partial class Title {
 						continue;
 					}
 					county.SetHolder(ck3Owner, conversionDate);
+					county.SetDeFactoLiege(deFactoLiege, conversionDate);
+					
 				} else {
 					barony.SetHolder(ck3Owner, conversionDate);
+					barony.SetDeFactoLiege(deFactoLiege, conversionDate);
 				}
 				++counter;
 			}

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -514,7 +514,6 @@ public partial class Title {
 					}
 					county.SetHolder(ck3Owner, conversionDate);
 					county.SetDeFactoLiege(deFactoLiege, conversionDate);
-					
 				} else {
 					barony.SetHolder(ck3Owner, conversionDate);
 					barony.SetDeFactoLiege(deFactoLiege, conversionDate);

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -186,10 +186,12 @@ public class World {
 			coaMapper,
 			countyLevelGovernorships
 		);
-
-		LandedTitles.ImportImperatorHoldings(Provinces, impWorld.Characters, CorrectedDate);
-
+		
+		// Give counties to rulers and governors.
 		OverwriteCountiesHistory(impWorld.Jobs.Governorships, countyLevelGovernorships, impWorld.Characters, CorrectedDate);
+		// Import holding owners as barons and counts.
+		LandedTitles.ImportImperatorHoldings(Provinces, impWorld.Characters, CorrectedDate);
+		
 		LandedTitles.ImportDevelopmentFromImperator(Provinces, CorrectedDate, config.ImperatorCivilizationWorth);
 		LandedTitles.RemoveInvalidLandlessTitles(config.CK3BookmarkDate);
 		if (!config.StaticDeJure) {

--- a/ImperatorToCK3/Imperator/World.cs
+++ b/ImperatorToCK3/Imperator/World.cs
@@ -1,4 +1,5 @@
 using commonItems;
+using commonItems.Collections;
 using commonItems.Colors;
 using commonItems.Localization;
 using commonItems.Mods;
@@ -201,7 +202,7 @@ public class World : Parser {
 		RegisterKeyword("deity_manager", reader => {
 			Religions.LoadHolySiteDatabase(reader);
 		});
-		var playerCountriesToLog = new List<string>();
+		var playerCountriesToLog = new OrderedSet<string>();
 		RegisterKeyword("played_country", reader => {
 			var playedCountryBlocParser = new Parser();
 			playedCountryBlocParser.RegisterKeyword("country", reader => {


### PR DESCRIPTION
It's now possible for a holding owner to be converted to a count. Previously only barons were possible.