### PR TITLE
Fix converter backend outputting mod to wrong directory

### DIFF
--- a/ImperatorToCK3/Configuration.cs
+++ b/ImperatorToCK3/Configuration.cs
@@ -202,7 +202,6 @@ public class Configuration {
 		if (OutputModName.Length == 0) {
 			OutputModName = CommonFunctions.TrimPath(SaveGamePath);
 		}
-		OutputModName = CommonFunctions.TrimExtension(OutputModName);
 		OutputModName = OutputModName.Replace('-', '_');
 		OutputModName = OutputModName.Replace(' ', '_');
 


### PR DESCRIPTION
Sentry event ID: 2842913aa965483b9ff3f06eaeee4ad1