### PR TITLE
Change the way CK3 development from I:R is calculated

### DIFF
--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -1143,7 +1143,7 @@ public partial class Title {
 						continue;
 					}
 
-					dev += sourceProvinces.Average(srcProv => srcProv.CivilizationValue / ck3ProvsPerIRProv[srcProv.Id]);
+					dev += sourceProvinces.Sum(srcProv => srcProv.CivilizationValue / ck3ProvsPerIRProv[srcProv.Id]);
 				}
 
 				dev *= irCivilizationWorth;


### PR DESCRIPTION
Previously, the development calculated for a CK3 province was an average of the civilisation values from corresponding Imperator provinces. Now it's a sum.