### PR TITLE
Fix exception while loading dynasty houses from CK3

### DIFF
--- a/ImperatorToCK3/CK3/Dynasties/HouseCollection.cs
+++ b/ImperatorToCK3/CK3/Dynasties/HouseCollection.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace ImperatorToCK3.CK3.Dynasties;
 
-public class HouseCollection : IdObjectCollection<string, House> {
+public class HouseCollection : ConcurrentIdObjectCollection<string, House> {
 	public void LoadCK3Houses(ModFilesystem ck3ModFS) {
 		Logger.Info("Loading dynasty houses from CK3...");
 		


### PR DESCRIPTION
Sentry event ID: ace81263d6e2427582c49a054e630d4c