### PR TITLE
Government office conversion

### DIFF
--- a/ImperatorToCK3.UnitTests/Imperator/Jobs/JobsTests.cs
+++ b/ImperatorToCK3.UnitTests/Imperator/Jobs/JobsTests.cs
@@ -2,6 +2,7 @@
 using commonItems.Colors;
 using commonItems.Mods;
 using ImperatorToCK3.CommonUtils.Map;
+using ImperatorToCK3.Imperator.Characters;
 using ImperatorToCK3.Imperator.Countries;
 using ImperatorToCK3.Imperator.Geography;
 using ImperatorToCK3.Mappers.Region;
@@ -41,7 +42,7 @@ public class JobsTests {
 		var reader = new BufferedReader(
 			"province_job={who=1 governorship=galatia_region} province_job={who=2 governorship=galatia_region}"
 		);
-		var jobs = new ImperatorToCK3.Imperator.Jobs.JobsDB(reader, countryCollection, irRegionMapper);
+		var jobs = new ImperatorToCK3.Imperator.Jobs.JobsDB(reader, new CharacterCollection(), countryCollection, irRegionMapper);
 		Assert.Collection(jobs.Governorships,
 			item1 => Assert.Equal((ulong)1, item1.Country.Id),
 			item2 => Assert.Equal((ulong)2, item2.Country.Id)
@@ -55,7 +56,7 @@ public class JobsTests {
 		var reader = new BufferedReader(
 			"useless_job = {}"
 		);
-		_ = new ImperatorToCK3.Imperator.Jobs.JobsDB(reader, countryCollection, irRegionMapper);
+		_ = new ImperatorToCK3.Imperator.Jobs.JobsDB(reader, new CharacterCollection(), countryCollection, irRegionMapper);
 
 		Assert.Contains("Ignored Jobs tokens: useless_job", output.ToString());
 	}

--- a/ImperatorToCK3.sln.DotSettings
+++ b/ImperatorToCK3.sln.DotSettings
@@ -91,6 +91,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Petair/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Phrygian/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playset/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pontifex/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Provs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Qahtanite/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rakaly/@EntryIndexedValue">True</s:Boolean>

--- a/ImperatorToCK3/CK3/Religions/Faith.cs
+++ b/ImperatorToCK3/CK3/Religions/Faith.cs
@@ -74,6 +74,10 @@ public sealed class Faith : IIdentifiable<string>, IPDXSerializable {
 
 	public string? GetDoctrineIdForDoctrineCategoryId(string doctrineCategoryId) {
 		var category = Religion.ReligionCollection.DoctrineCategories[doctrineCategoryId];
+		return GetDoctrineIdForDoctrineCategory(category);
+	}
+
+	private string? GetDoctrineIdForDoctrineCategory(DoctrineCategory category) {
 		var potentialDoctrineIds = category.DoctrineIds;
 		
 		// Look in faith first. If not found, look in religion.
@@ -82,6 +86,12 @@ public sealed class Faith : IIdentifiable<string>, IPDXSerializable {
 	}
 	
 	public bool HasDoctrine(string doctrineId) {
-		return DoctrineIds.Contains(doctrineId) || Religion.DoctrineIds.Contains(doctrineId);
+		var category = Religion.ReligionCollection.DoctrineCategories
+			.FirstOrDefault(category => category.DoctrineIds.Contains(doctrineId));
+		if (category is null) {
+			return false;
+		}
+		
+		return GetDoctrineIdForDoctrineCategory(category) == doctrineId;
 	}
 }

--- a/ImperatorToCK3/CK3/Religions/Faith.cs
+++ b/ImperatorToCK3/CK3/Religions/Faith.cs
@@ -80,4 +80,8 @@ public sealed class Faith : IIdentifiable<string>, IPDXSerializable {
 		var matchingInFaith = DoctrineIds.Intersect(potentialDoctrineIds).LastOrDefault();
 		return matchingInFaith ?? Religion.DoctrineIds.Intersect(potentialDoctrineIds).LastOrDefault();
 	}
+	
+	public bool HasDoctrine(string doctrineId) {
+		return DoctrineIds.Contains(doctrineId) || Religion.DoctrineIds.Contains(doctrineId);
+	}
 }

--- a/ImperatorToCK3/CK3/Religions/Faith.cs
+++ b/ImperatorToCK3/CK3/Religions/Faith.cs
@@ -11,7 +11,7 @@ namespace ImperatorToCK3.CK3.Religions;
 
 public sealed class Faith : IIdentifiable<string>, IPDXSerializable {
 	public string Id { get; }
-	public Religion Religion { get; }
+	public Religion Religion { get; set; }
 	public Color? Color { get; }
 	public string? ReligiousHeadTitleId { get; }
 	public OrderedSet<string> DoctrineIds { get; }
@@ -79,7 +79,7 @@ public sealed class Faith : IIdentifiable<string>, IPDXSerializable {
 
 	private string? GetDoctrineIdForDoctrineCategory(DoctrineCategory category) {
 		var potentialDoctrineIds = category.DoctrineIds;
-		
+
 		// Look in faith first. If not found, look in religion.
 		var matchingInFaith = DoctrineIds.Intersect(potentialDoctrineIds).LastOrDefault();
 		return matchingInFaith ?? Religion.DoctrineIds.Intersect(potentialDoctrineIds).LastOrDefault();

--- a/ImperatorToCK3/CK3/Religions/ReligionCollection.cs
+++ b/ImperatorToCK3/CK3/Religions/ReligionCollection.cs
@@ -46,6 +46,7 @@ public sealed class ReligionCollection(Title.LandedTitles landedTitles) : IdObje
 			// Otherwise, add the converter faith's religion.
 			if (TryGetValue(religionId, out var religion)) {
 				foreach (var faith in optReligion.Faiths) {
+					faith.Religion = religion;
 					religion.Faiths.Add(faith);
 				}
 			} else {

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -1272,6 +1272,8 @@ public sealed partial class Title {
 				["chronicler_court_position"] = ["office_philosopher"], // From I:R wiki: "supervises libraries and the gathering and protection of knowledge"
 				["court_cave_hermit_position"] = ["office_wise_person"]
 			};
+			
+			// TODO: also convert to Realm Priest court position
 
 			// TODO: log all office types found in the save that are not mapped to CK3 offices
 

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -1252,7 +1252,7 @@ public sealed partial class Title {
 		/// https://ck3.paradoxwikis.com/Council
 		/// https://ck3.paradoxwikis.com/Court#Court_positions
 		/// </summary>
-		public void ImportImperatorGovernmentOffices(ICollection<OfficeJob> irOfficeJobs, ReligionCollection religionCollection) {
+		public void ImportImperatorGovernmentOffices(ICollection<OfficeJob> irOfficeJobs, ReligionCollection religionCollection, Date bookmarkDate) {
 			Logger.Info("Converting government offices...");
 			var titlesFromImperator = GetCountriesImportedFromImperator();
 			
@@ -1284,13 +1284,18 @@ public sealed partial class Title {
 					continue;
 				}
 				
+				// Make sure the ruler actually holds something in CK3.
+				if (this.All(t => t.GetHolderId(bookmarkDate) != ck3Ruler.Id)) {
+					continue;
+				}
+				
 				var convertibleJobs = irOfficeJobs.Where(j => j.CountryId == country.Id).ToList();
 				if (convertibleJobs.Count == 0) {
 					continue;
 				}
 				
 				var alreadyEmployedCharacters = new HashSet<string>();
-				title.AppointCouncilMembersFromImperator(religionCollection, councilPositionToSourcesDict, convertibleJobs, alreadyEmployedCharacters, ck3Ruler);
+				title.AppointCouncilMembersFromImperator(religionCollection, councilPositionToSourcesDict, convertibleJobs, alreadyEmployedCharacters, ck3Ruler, bookmarkDate);
 				title.AppointCourtierPositionsFromImperator(courtPositionToSourcesDict, convertibleJobs, alreadyEmployedCharacters, ck3Ruler);
 			}
 		}

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -1259,7 +1259,7 @@ public sealed partial class Title {
 			var councilPositionToSourcesDict = new Dictionary<string, string[]> {
 				["councillor_court_chaplain"] = ["office_augur", "office_pontifex", "office_high_priest_monarchy", "office_high_priest", "office_wise_person"],
 				["councillor_chancellor"] = ["office_censor", "office_foreign_minister", "office_arbitrator", "office_elder"],
-				["councillor_steward"] = ["office_magistrate", "office_steward", "office_tribune_of_the_treasury"],
+				["councillor_steward"] = ["office_praetor", "office_magistrate", "office_steward", "office_tribune_of_the_treasury"],
 				["councillor_marshal"] = ["office_tribune_of_the_soldiers", "office_marshal", "office_master_of_the_guard", "office_warchief", "office_bodyguard"],
 				["councillor_spymaster"] = [], // No equivalents found in Imperator.
 			};
@@ -1272,10 +1272,16 @@ public sealed partial class Title {
 				["chronicler_court_position"] = ["office_philosopher"], // From I:R wiki: "supervises libraries and the gathering and protection of knowledge"
 				["court_cave_hermit_position"] = ["office_wise_person"]
 			};
-			
-			// TODO: also convert to Realm Priest court position
 
-			// TODO: log all office types found in the save that are not mapped to CK3 offices
+			string[] ignoredOfficeTypes = ["office_plebeian_aedile"];
+
+			// Log all unhandled office types.
+			var irOfficeTypesFromSave = irOfficeJobs.Select(j => j.OfficeType).ToHashSet();
+			var handledOfficeTypes = councilPositionToSourcesDict.Values.SelectMany(v => v).Concat(courtPositionToSourcesDict.Values.SelectMany(v => v)).Concat(ignoredOfficeTypes).ToHashSet();
+			var unmappedOfficeTypes = irOfficeTypesFromSave.Where(officeType => !handledOfficeTypes.Contains(officeType)).ToList();
+			if (unmappedOfficeTypes.Count > 0) {
+				Logger.Error($"Unmapped office types: {string.Join(", ", unmappedOfficeTypes)}");
+			}
 
 			foreach (var title in titlesFromImperator) {
 				var country = title.ImperatorCountry!;
@@ -1296,7 +1302,7 @@ public sealed partial class Title {
 				
 				var alreadyEmployedCharacters = new HashSet<string>();
 				title.AppointCouncilMembersFromImperator(religionCollection, councilPositionToSourcesDict, convertibleJobs, alreadyEmployedCharacters, ck3Ruler, bookmarkDate);
-				title.AppointCourtierPositionsFromImperator(courtPositionToSourcesDict, convertibleJobs, alreadyEmployedCharacters, ck3Ruler);
+				title.AppointCourtierPositionsFromImperator(courtPositionToSourcesDict, convertibleJobs, alreadyEmployedCharacters, ck3Ruler, bookmarkDate);
 			}
 		}
 

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -7,6 +7,7 @@ using commonItems.Serialization;
 using commonItems.SourceGenerators;
 using ImperatorToCK3.CK3.Characters;
 using ImperatorToCK3.CK3.Provinces;
+using ImperatorToCK3.CK3.Religions;
 using ImperatorToCK3.CommonUtils;
 using ImperatorToCK3.Imperator.Countries;
 using ImperatorToCK3.Imperator.Diplomacy;
@@ -196,7 +197,7 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 
 		ClearHolderSpecificHistory();
 
-		FillHolderAndGovernmentHistory();
+		FillHolderAndGovernmentHistory(country, characters, governmentMapper, locDB, religionMapper, cultureMapper, nicknameMapper, provinceMapper, config, conversionDate);
 
 		// Determine color.
 		var color1Opt = ImperatorCountry.Color1;
@@ -269,50 +270,6 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 		// determine adjective localization
 		TrySetAdjectiveLoc(locDB, imperatorCountries);
 
-		void FillHolderAndGovernmentHistory() {
-			// ------------------ determine previous and current holders
-
-			foreach (var impRulerTerm in ImperatorCountry.RulerTerms) {
-				var rulerTerm = new RulerTerm(
-					impRulerTerm,
-					characters,
-					governmentMapper,
-					locDB,
-					religionMapper,
-					cultureMapper,
-					nicknameMapper,
-					provinceMapper,
-					config
-				);
-
-				var characterId = rulerTerm.CharacterId;
-				if (characterId is null) {
-					continue;
-				}
-				var gov = rulerTerm.Government;
-
-				var termStartDate = new Date(rulerTerm.StartDate);
-				var ruler = characters[characterId];
-				if (ruler.DeathDate is not null && ruler.DeathDate < termStartDate) {
-					Logger.Warn($"{ruler.Id} can not begin his rule over {Id} after his death, skipping!");
-					continue;
-				}
-
-				History.AddFieldValue(termStartDate, "holder", "holder", characterId);
-				if (gov is not null) {
-					History.AddFieldValue(termStartDate, "government", "government", gov);
-				}
-			}
-
-			if (ImperatorCountry.Government is not null) {
-				var lastCK3TermGov = GetGovernment(conversionDate);
-				var ck3CountryGov = governmentMapper.GetCK3GovernmentForImperatorGovernment(ImperatorCountry.Government, ImperatorCountry.PrimaryCulture);
-				if (lastCK3TermGov != ck3CountryGov && ck3CountryGov is not null) {
-					History.AddFieldValue(conversionDate, "government", "government", ck3CountryGov);
-				}
-			}
-		}
-		
 		// If country is a subject, convert it to a vassal.
 		if (dependency is not null) {
 			var overLordTitle = imperatorCountries[dependency.OverlordId].CK3Title;
@@ -321,6 +278,62 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 			}
 			DeJureLiege = overLordTitle;
 			SetDeFactoLiege(overLordTitle, dependency.StartDate);
+		}
+	}
+	
+	/// <summary>
+	/// Fills title's history with Imperator and pre-Imperator rulers and sets appropriate government.
+	/// </summary>
+	private void FillHolderAndGovernmentHistory(Country imperatorCountry,
+		CharacterCollection characters,
+		GovernmentMapper governmentMapper,
+		LocDB locDB,
+		ReligionMapper religionMapper,
+		CultureMapper cultureMapper,
+		NicknameMapper nicknameMapper,
+		ProvinceMapper provinceMapper,
+		Configuration config,
+		Date conversionDate) {
+		// ------------------ determine previous and current holders
+
+		foreach (var impRulerTerm in imperatorCountry.RulerTerms) {
+			var rulerTerm = new RulerTerm(
+				impRulerTerm,
+				characters,
+				governmentMapper,
+				locDB,
+				religionMapper,
+				cultureMapper,
+				nicknameMapper,
+				provinceMapper,
+				config
+			);
+
+			var characterId = rulerTerm.CharacterId;
+			if (characterId is null) {
+				continue;
+			}
+			var gov = rulerTerm.Government;
+
+			var termStartDate = new Date(rulerTerm.StartDate);
+			var ruler = characters[characterId];
+			if (ruler.DeathDate is not null && ruler.DeathDate < termStartDate) {
+				Logger.Warn($"{ruler.Id} can not begin his rule over {Id} after his death, skipping!");
+				continue;
+			}
+
+			History.AddFieldValue(termStartDate, "holder", "holder", characterId);
+			if (gov is not null) {
+				History.AddFieldValue(termStartDate, "government", "government", gov);
+			}
+		}
+
+		if (imperatorCountry.Government is not null) {
+			var lastCK3TermGov = GetGovernment(conversionDate);
+			var ck3CountryGov = governmentMapper.GetCK3GovernmentForImperatorGovernment(imperatorCountry.Government, imperatorCountry.PrimaryCulture);
+			if (lastCK3TermGov != ck3CountryGov && ck3CountryGov is not null) {
+				History.AddFieldValue(conversionDate, "government", "government", ck3CountryGov);
+			}
 		}
 	}
 
@@ -1194,6 +1207,119 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 			'e' => TitleRank.empire,
 			_ => throw new FormatException($"Title {titleId}: unknown rank!")
 		};
+	}
+	
+	
+
+	internal void AppointCourtierPositionsFromImperator(Dictionary<string, string[]> courtPositionToSourcesDict,
+		List<OfficeJob> convertibleJobs,
+		HashSet<string> alreadyEmployedCharacters, 
+		Character ck3Ruler) {
+		foreach (var (ck3Position, sources) in courtPositionToSourcesDict) {
+			// The order of I:R source position types is important - the first filled one found will be used.
+			foreach (var sourceOfficeType in sources) {
+				var job = convertibleJobs.Find(o => o.OfficeType == sourceOfficeType);
+				if (job is null) {
+					continue;
+				}
+
+				var ck3Official = job.Character.CK3Character;
+				if (ck3Official is null) {
+					continue;
+				}
+				if (alreadyEmployedCharacters.Contains(ck3Official.Id)) {
+					continue;
+				}
+				
+				// A ruler cannot be their own courtier.
+				if (ck3Official.Id == ck3Ruler.Id) {
+					continue;
+				}
+					
+				var courtPositionEffect = new StringOfItem($$"""
+				{
+					character:{{ck3Official.Id}} = {
+					    set_employer = prev
+					}
+					appoint_court_position = {
+					    recipient = character:{{ck3Official.Id}}
+					    court_position = {{ck3Position}}
+					}
+				}
+				""");
+				ck3Ruler.History.AddFieldValue(job.StartDate, "effects", "effect", courtPositionEffect); // TODO: check if this works
+					
+				if (Localizations.GetLocBlockForKey(Id)?["english"] is { } name && name.Contains("Sardinia"))
+					Logger.Notice($"Imported Imperator official {job.Character.Id} as COURT {ck3Position} for {ck3Ruler.Id}"); // TODO: remove this
+					
+				// One character should only hold one CK3 position.
+				convertibleJobs.Remove(job);
+				alreadyEmployedCharacters.Add(ck3Official.Id);
+					
+				break;
+			}
+		}
+	}
+
+	internal void AppointCouncilMembersFromImperator(ReligionCollection religionCollection,
+		Dictionary<string, string[]> councilPositionToSourcesDict, 
+		List<OfficeJob> convertibleJobs, 
+		HashSet<string> alreadyEmployedCharacters,
+		Character ck3Ruler) {
+		foreach (var (ck3Position, sources) in councilPositionToSourcesDict) {
+			// The order of I:R source position types is important - the first filled one found will be used.
+			foreach (var sourceOfficeType in sources) {
+				var job = convertibleJobs.Find(o => o.OfficeType == sourceOfficeType);
+				if (job is null) {
+					continue;
+				}
+
+				var ck3Official = job.Character.CK3Character;
+				if (ck3Official is null) {
+					continue;
+				}
+				if (alreadyEmployedCharacters.Contains(ck3Official.Id)) {
+					continue;
+				}
+				
+				// A ruler cannot be their own councillor.
+				if (ck3Official.Id == ck3Ruler.Id) {
+					continue;
+				}
+
+				if (ck3Position == "councillor_court_chaplain") {
+					// Court chaplains need to have the same faith as the ruler.
+					if (ck3Ruler.GetFaithId(job.StartDate) != ck3Official.GetFaithId(job.StartDate)) {
+						continue;
+					}
+				} else if (ck3Position == "councillor_steward" || ck3Position == "councillor_chancellor" || ck3Position == "councillor_marshal") {
+					// Stewards, chancellors and marshals need to have the dominant gender of the faith.
+					var courtFaith = ck3Ruler.GetFaithId(job.StartDate);
+					if (courtFaith is not null) {
+						var dominantGenderDoctrine = religionCollection.GetFaith(courtFaith)?
+							.GetDoctrineIdForDoctrineCategoryId("doctrine_gender");
+						if (dominantGenderDoctrine == "doctrine_gender_male_dominated" && ck3Official.Female) {
+							continue;
+						}
+						if (dominantGenderDoctrine == "doctrine_gender_female_dominated" && !ck3Official.Female) {
+							continue;
+						}
+					}
+				}
+					
+				ck3Official.History.AddFieldValue(job.StartDate, "employer", "employer", ck3Ruler.Id);
+				ck3Official.History.AddFieldValue(job.StartDate, "council_position", "give_council_position", ck3Position); // TODO: test if this works
+
+				if (Localizations.GetLocBlockForKey(Id)?["english"] is { } name && name.Contains("Sardinia"))
+					Logger.Notice($"Imported Imperator official {job.Character.Id}  as COUNCIL {ck3Position} for {ck3Ruler.Id}"); // TODO: remove this
+					
+				// One character should only hold one CK3 position.
+				convertibleJobs.Remove(job);
+				alreadyEmployedCharacters.Add(ck3Official.Id);
+					
+				break;
+			}
+		}
 	}
 
 	// used by county titles only

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -1244,12 +1244,17 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 				if (heldTitlesPerCharacterCache[ck3Official.Id] > 0) {
 					continue;
 				}
+				
+				// For court_cave_hermit_position, lifestyle_mystic trait is required.
+				if (ck3Position == "court_cave_hermit_position" && !ck3Official.BaseTraits.Contains("lifestyle_mystic")) {
+					continue;
+				}
 					
 				var courtPositionEffect = new StringOfItem($$"""
 				{
 					character:{{ck3Official.Id}} = {
 						if = {
-							limit = { prev = { NOT = { is_employer_of = character:{{ck3Official.Id}} } }
+							limit = { prev = { NOT = { is_employer_of = character:{{ck3Official.Id}} } } }
 							set_employer = prev
 						}
 					}
@@ -1260,7 +1265,6 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 				}
 				""");
 				ck3Ruler.History.AddFieldValue(bookmarkDate, "effects", "effect", courtPositionEffect); // TODO: check if this works
-					
 					
 				// One character should only hold one CK3 position.
 				convertibleJobs.Remove(job);
@@ -1336,8 +1340,11 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 					}
 				}
 				
-				ck3Official.History.AddFieldValue(bookmarkDate, "employer", "employer", ck3Ruler.Id);
-				ck3Official.History.AddFieldValue(bookmarkDate, "council_position", "give_council_position", ck3Position); // TODO: test if this works
+				// We only need to set the employer when the council member is landless.
+				if (heldTitlesPerCharacterCache[ck3Official.Id] == 0) {
+					ck3Official.History.AddFieldValue(bookmarkDate, "employer", "employer", ck3Ruler.Id);
+				}
+				ck3Official.History.AddFieldValue(bookmarkDate, "council_position", "give_council_position", ck3Position);
 					
 				// One character should only hold one CK3 position.
 				convertibleJobs.Remove(job);

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -1264,7 +1264,7 @@ public sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 					}
 				}
 				""");
-				ck3Ruler.History.AddFieldValue(bookmarkDate, "effects", "effect", courtPositionEffect); // TODO: check if this works
+				ck3Ruler.History.AddFieldValue(bookmarkDate, "effects", "effect", courtPositionEffect);
 					
 				// One character should only hold one CK3 position.
 				convertibleJobs.Remove(job);

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -267,8 +267,6 @@ public sealed class World {
 		OverwriteCountiesHistory(impWorld.Countries, impWorld.JobsDB.Governorships, countyLevelCountries, countyLevelGovernorships, impWorld.Characters, impWorld.Provinces, CorrectedDate);
 		// Import holding owners as barons and counts.
 		LandedTitles.ImportImperatorHoldings(Provinces, impWorld.Characters, CorrectedDate);
-		// Now that we have imported all the land holders, determine council and court positions.
-		LandedTitles.ImportImperatorGovernmentOffices(impWorld.JobsDB.OfficeJobs, Religions, config.CK3BookmarkDate);
 		
 		LandedTitles.ImportDevelopmentFromImperator(Provinces, CorrectedDate, config.ImperatorCivilizationWorth);
 		LandedTitles.RemoveInvalidLandlessTitles(config.CK3BookmarkDate);
@@ -289,6 +287,9 @@ public sealed class World {
 
 		Characters.RemoveEmployerIdFromLandedCharacters(LandedTitles, CorrectedDate);
 		Characters.PurgeUnneededCharacters(LandedTitles, Dynasties, DynastyHouses, config.CK3BookmarkDate);
+		
+		// Now that the title history is basicaly done, convert officials as council members and courtiers.
+		LandedTitles.ImportImperatorGovernmentOffices(impWorld.JobsDB.OfficeJobs, Religions, config.CK3BookmarkDate);
 		
 		// Check if any muslim religion exists in Imperator. Otherwise, remove Islam from the entire CK3 map.
 		var possibleMuslimReligionNames = new List<string> { "muslim", "islam", "sunni", "shiite" };

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -240,7 +240,6 @@ public sealed class World {
 			config,
 			countyLevelCountries
 		);
-		LandedTitles.ImportImperatorGovernmentOffices(impWorld.JobsDB.OfficeJobs, Religions);
 
 		// Now we can deal with provinces since we know to whom to assign them. We first import vanilla province data.
 		// Some of it will be overwritten, but not all.
@@ -268,6 +267,8 @@ public sealed class World {
 		OverwriteCountiesHistory(impWorld.Countries, impWorld.JobsDB.Governorships, countyLevelCountries, countyLevelGovernorships, impWorld.Characters, impWorld.Provinces, CorrectedDate);
 		// Import holding owners as barons and counts.
 		LandedTitles.ImportImperatorHoldings(Provinces, impWorld.Characters, CorrectedDate);
+		// Now that we have imported all the land holders, determine council and court positions.
+		LandedTitles.ImportImperatorGovernmentOffices(impWorld.JobsDB.OfficeJobs, Religions, config.CK3BookmarkDate);
 		
 		LandedTitles.ImportDevelopmentFromImperator(Provinces, CorrectedDate, config.ImperatorCivilizationWorth);
 		LandedTitles.RemoveInvalidLandlessTitles(config.CK3BookmarkDate);

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -240,6 +240,7 @@ public sealed class World {
 			config,
 			countyLevelCountries
 		);
+		LandedTitles.ImportImperatorGovernmentOffices(impWorld.JobsDB.OfficeJobs, Religions);
 
 		// Now we can deal with provinces since we know to whom to assign them. We first import vanilla province data.
 		// Some of it will be overwritten, but not all.

--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -288,7 +288,7 @@ public sealed class World {
 		Characters.RemoveEmployerIdFromLandedCharacters(LandedTitles, CorrectedDate);
 		Characters.PurgeUnneededCharacters(LandedTitles, Dynasties, DynastyHouses, config.CK3BookmarkDate);
 		
-		// Now that the title history is basicaly done, convert officials as council members and courtiers.
+		// Now that the title history is basically done, convert officials as council members and courtiers.
 		LandedTitles.ImportImperatorGovernmentOffices(impWorld.JobsDB.OfficeJobs, Religions, config.CK3BookmarkDate);
 		
 		// Check if any muslim religion exists in Imperator. Otherwise, remove Islam from the entire CK3 map.

--- a/ImperatorToCK3/Imperator/Jobs/JobsDB.cs
+++ b/ImperatorToCK3/Imperator/Jobs/JobsDB.cs
@@ -1,23 +1,33 @@
 ﻿using commonItems;
 using ImperatorToCK3.CommonUtils;
+using ImperatorToCK3.Imperator.Characters;
 using ImperatorToCK3.Imperator.Countries;
 using ImperatorToCK3.Mappers.Region;
+using System;
 using System.Collections.Generic;
 
 namespace ImperatorToCK3.Imperator.Jobs;
 
 public sealed class JobsDB {
-	public IList<Governorship> Governorships { get; } = new List<Governorship>();
+	public IList<Governorship> Governorships { get; } = [];
+	public IList<OfficeJob> OfficeJobs { get; } = [];
 
 	public JobsDB() { }
-	public JobsDB(BufferedReader jobsReader, CountryCollection countries, ImperatorRegionMapper irRegionMapper) {
+	public JobsDB(BufferedReader jobsReader, CharacterCollection characters, CountryCollection countries, ImperatorRegionMapper irRegionMapper) {
 		var ignoredTokens = new IgnoredKeywordsSet();
 		var parser = new Parser();
 		parser.RegisterKeyword("province_job", reader => {
 			try {
 				Governorships.Add(new Governorship(reader, countries, irRegionMapper));
-			} catch (System.Exception ex) {
+			} catch (Exception ex) {
 				Logger.Warn($"Failed to load governorship: {ex.Message}");
+			}
+		});
+		parser.RegisterKeyword("office_job", reader => {
+			try {
+				OfficeJobs.Add(new OfficeJob(reader, characters));
+			} catch (Exception ex) {
+				Logger.Warn($"Failed to load office job: {ex.Message}");
 			}
 		});
 		parser.IgnoreAndStoreUnregisteredItems(ignoredTokens);

--- a/ImperatorToCK3/Imperator/Jobs/OfficeJob.cs
+++ b/ImperatorToCK3/Imperator/Jobs/OfficeJob.cs
@@ -1,0 +1,31 @@
+using commonItems;
+using ImperatorToCK3.Imperator.Characters;
+using System;
+
+namespace ImperatorToCK3.Imperator.Jobs;
+
+public class OfficeJob {
+	public ulong CountryId { get; }
+	public Character Character { get; private set; }
+	public Date StartDate { get; private set; } = new(1, 1, 1);
+	public string OfficeType { get; }
+	
+	public OfficeJob(BufferedReader reader, CharacterCollection irCharacters) {
+		ulong? countryId = null;
+		ulong? characterId = null;
+		string? officeType = null;
+
+		var parser = new Parser();
+		parser.RegisterKeyword("who", r => countryId = r.GetULong());
+		parser.RegisterKeyword("character", r => characterId = r.GetULong());
+		parser.RegisterKeyword("start_date", r => StartDate = new Date(r.GetString(), AUC: true));
+		parser.RegisterKeyword("office", r => officeType = r.GetString());
+		parser.IgnoreAndLogUnregisteredItems();
+
+		parser.ParseStream(reader);
+
+		CountryId = countryId ?? throw new FormatException("Country ID missing!");
+		Character = irCharacters[characterId ?? throw new FormatException("Character ID missing!")];
+		OfficeType = officeType ?? throw new FormatException("Office type missing!");
+	}
+}

--- a/ImperatorToCK3/Imperator/World.cs
+++ b/ImperatorToCK3/Imperator/World.cs
@@ -201,7 +201,7 @@ public class World {
 
 	private void LoadJobs(BufferedReader reader) {
 		Logger.Info("Loading Jobs...");
-		JobsDB = new Jobs.JobsDB(reader, Countries, ImperatorRegionMapper);
+		JobsDB = new Jobs.JobsDB(reader, Characters, Countries, ImperatorRegionMapper);
 		Logger.Info($"Loaded {JobsDB.Governorships.Count} governorships.");
 		Logger.IncrementProgress();
 	}


### PR DESCRIPTION
The program now converts Imperator government officials to court chaplains, chancellors, stewards, marshals, bodyguards, court physicians, court tutors and chroniclers.

closes #89 