### PR TITLE
Prevent exception while creating dynasties when a converter-generated mod is selected as one of the CK3 mods

### DIFF
--- a/ImperatorToCK3/CK3/Dynasties/DynastyCollection.cs
+++ b/ImperatorToCK3/CK3/Dynasties/DynastyCollection.cs
@@ -78,7 +78,7 @@ public sealed class DynastyCollection : ConcurrentIdObjectCollection<string, Dyn
 
 			// Neither character nor their father have a dynasty, so we need to create a new one.
 			var newDynasty = new Dynasty(ck3Character, irFamilyName, irWorld.CulturesDB, irLocDB, ck3LocDB, date);
-			Add(newDynasty);
+			AddOrReplace(newDynasty);
 			++createdDynastiesCount;
 		}
 


### PR DESCRIPTION
Sentry event ID: e8422b6133144fa78a9047b602794072