### PR TITLE
Implement standard constructors for UserErrorException and ConverterException

### DIFF
--- a/ImperatorToCK3/Exceptions/ConverterException.cs
+++ b/ImperatorToCK3/Exceptions/ConverterException.cs
@@ -5,6 +5,7 @@ namespace ImperatorToCK3.Exceptions;
 public class ConverterException : Exception {
 	public ConverterException(string message) : base(message) { }
 
-	public ConverterException(string? message, Exception? innerException) : base(message, innerException) {
-	}
+	public ConverterException(string? message, Exception? innerException) : base(message, innerException) { }
+
+	public ConverterException() : base() { }
 }

--- a/ImperatorToCK3/Exceptions/UserErrorException.cs
+++ b/ImperatorToCK3/Exceptions/UserErrorException.cs
@@ -2,9 +2,10 @@ using System;
 
 namespace ImperatorToCK3.Exceptions;
 
-class UserErrorException : ConverterException {
+internal class UserErrorException : ConverterException {
     public UserErrorException(string message) : base(message) { }
 
-    public UserErrorException(string? message, Exception? innerException) : base(message, innerException) {
-    }
+    public UserErrorException(string? message, Exception? innerException) : base(message, innerException) { }
+
+    public UserErrorException() : base() { }
 }


### PR DESCRIPTION
Not needed in the code for now, but fixes warnings.