### PR TITLE
Fix revolt localization when an unlocalized name is used as base

### DIFF
--- a/ImperatorToCK3.UnitTests/Imperator/Countries/CountryNameTests.cs
+++ b/ImperatorToCK3.UnitTests/Imperator/Countries/CountryNameTests.cs
@@ -226,4 +226,31 @@ public class CountryNameTests {
 		Assert.Equal("Nikonia Revolt", countryName.GetNameLocBlock(locDB, [])!["english"]);
 		Assert.Equal("Nikonia", countryName.GetAdjectiveLocBlock(locDB, [])!["english"]);
 	}
+
+	[Fact]
+	public void RawBaseNameCanBeUsedForRevoltTagNameAndAdjective() {
+		var reader = new BufferedReader(
+			"""
+			name="CIVILWAR_FACTION_NAME"
+			adjective="CIVILWAR_FACTION_ADJECTIVE"
+			base={
+				name="Tamilakam"
+			}
+			""");
+		var countryName = CountryName.Parse(reader);
+		
+		var locDB = new LocDB("english", "french");
+		var civilWarLocBlock = locDB.AddLocBlock("CIVILWAR_FACTION_NAME");
+		civilWarLocBlock["english"] = "$ADJ$ Revolt";
+		civilWarLocBlock["french"] = "Rébellion $ADJ$";
+		var civilWarAdjLocBlock = locDB.AddLocBlock("CIVILWAR_FACTION_ADJECTIVE");
+		civilWarAdjLocBlock["english"] = "$ADJ$";
+		civilWarAdjLocBlock["french"] = "$ADJ$";
+		
+		Assert.Equal("Tamilakam Revolt", countryName.GetNameLocBlock(locDB, [])!["english"]);
+		Assert.Equal("Tamilakam", countryName.GetAdjectiveLocBlock(locDB, [])!["english"]);
+		
+		Assert.Equal("Rébellion Tamilakam", countryName.GetNameLocBlock(locDB, [])!["french"]);
+		Assert.Equal("Tamilakam", countryName.GetAdjectiveLocBlock(locDB, [])!["french"]);
+	}
 }

--- a/ImperatorToCK3/Imperator/Countries/CountryName.cs
+++ b/ImperatorToCK3/Imperator/Countries/CountryName.cs
@@ -36,7 +36,13 @@ public sealed class CountryName : ICloneable {
 		var baseAdjLoc = BaseName.GetAdjectiveLocBlock(irLocDB, imperatorCountries) ??
 		                 BaseName.GetNameLocBlock(irLocDB, imperatorCountries);
 		if (baseAdjLoc is null) {
-			return directNameLocMatch;
+			// If the base name only has an unlocalized name, use it.
+			baseAdjLoc = new LocBlock(BaseName.Name, ConverterGlobals.PrimaryLanguage) {
+				[ConverterGlobals.PrimaryLanguage] = BaseName.Name,
+			};
+			foreach (var language in ConverterGlobals.SecondaryLanguages) {
+				baseAdjLoc[language] = BaseName.Name;
+			}
 		}
 
 		var locBlockToReturn = new LocBlock(Name, directNameLocMatch);
@@ -86,6 +92,16 @@ public sealed class CountryName : ICloneable {
 			// If the BaseName only has a name and no adjective, use the name.
 			var baseAdjLoc = BaseName?.GetAdjectiveLocBlock(irLocDB, imperatorCountries) ??
 			                 BaseName?.GetNameLocBlock(irLocDB, imperatorCountries);
+			// If neither localized adjective nor name is found, use the unlocalized name.
+			if (baseAdjLoc is null && BaseName is not null) {
+				baseAdjLoc = new LocBlock(BaseName.Name, ConverterGlobals.PrimaryLanguage) {
+					[ConverterGlobals.PrimaryLanguage] = BaseName.Name,
+				};
+				foreach (var language in ConverterGlobals.SecondaryLanguages) {
+					baseAdjLoc[language] = BaseName.Name;
+				}
+			}
+
 			if (baseAdjLoc is not null) {
 				var locBlockToReturn = new LocBlock(adjKey, directAdjLocMatch);
 				locBlockToReturn.ModifyForEveryLanguage(baseAdjLoc, (orig, modifying, language) => {


### PR DESCRIPTION
Example:
```
			country_name={
				name="CIVILWAR_FACTION_NAME"
				adjective="CIVILWAR_FACTION_ADJECTIVE"
				base={
					name="Tamilakam"
				}
			}
```