### PR TITLE
`neo_minoan` and `cretan` cultures

### DIFF
--- a/ImperatorToCK3/Data_Files/configurables/converter_cultures.txt
+++ b/ImperatorToCK3/Data_Files/configurables/converter_cultures.txt
@@ -10,6 +10,82 @@
 # 	vanilla = { gallic }
 # }
 
+neo_minoan = { # Other names can be neo_mycanaean or posiedian. This culture should only be be able to trigger in the converter if the 		       # holder of the culture has a kingdom or empire tier title. Otherwise, cretan should take place over it
+	      
+	      color = { 0.7 0.6 0.95 }
+
+	      heritige = heritage_ancient_greek
+	      language = language_ancient_greek
+	      ethos = ethos_bureaucratic
+
+	      name_list = name_list_ancient_greek
+	      martial_custom = marital_custom_male_only
+
+	      traditions = {
+		    tradition_culture_blending # Greek empires or kingdoms would usually try to integrate conquered cultures, look at 						       # alexander the great's empire as an example
+		    tradition_maritime_mercantilism # Cretans were heavy on trade within the mediterranean due to location of crete
+     	 	    tradition_seafarers
+		    tradition_artisans # Would become known for different goods due to control of surrounding territories of middle 					       # east and asia outside of greece
+		    tradition_imperial_tagmata # Greek culture was based around honor and disciple, example is alexander's empire
+		    tradition_beacon_of_learning # One of the first cultures to be well known for philosiphy, math, etc.
+	      }
+
+	      ethnicities = {
+		      10 = mediterranean_byzantine
+	      }
+
+	      coa_gfx = {
+		    byzantine_group_coa_gfx
+	      }
+	      building_gfx = {
+		         mediterranean_building_gfx
+	      }
+	      clothing_gfx = {
+		         byzantine_clothing_gfx
+	      }
+	      unit_gfx = { eastern_unit_gfx }
+}
+		
+
+cretan = {
+     INVALIDATED_BY = {
+		 vanilla = { cretan }  # In vanilla the cretan culture is a divergence from Greek, done through a descision 
+	 }
+
+	 color = { 0.7 0.6 0.95 }
+
+	 heritige = heritage_ancient_greek
+	 language = language_doric # Doric was used for everyday life while the main greek language at the time (Koine Greek) was used 					   # for governance and other matters of administration. The language could be switched to 						   # language_ancient_greek depending on specificity or simplicity needed.
+	 ethos = ethos_bellicose
+
+	 name_list = name_list_ancient_greek
+	 martial_custom = marital_custom_male_only
+
+	 traditions = {
+		 tradition_swords_for_hire
+		 tradition_legalistic
+		 tradition_maritime_mercantilism
+		 tradition_mountain_homes
+		 tradition_highland_warriors
+		 tradition_seafarers # Can be switched out with tradition_warrior_culture or tradition_ritualized_friendship.
+	 }
+
+	 ethnicities = {
+		10 = mediterranean_byzantine
+	 }
+
+	 coa_gfx = {
+		byzantine_group_coa_gfx
+	 }
+	 building_gfx = {
+		mediterranean_building_gfx
+	 }
+	 clothing_gfx = {
+		byzantine_clothing_gfx
+	 }
+	 unit_gfx = { eastern_unit_gfx }
+}
+	 
 
 khasi = {
     INVALIDATED_BY = {


### PR DESCRIPTION
> I just added two cultures to the list neo_minoan and cretan. Both are at the top. Gelonian and Qin will be added later.

~@Voldarius

Stuff that needs to be added:

- [ ] Qin and Gelonian culture definitions
- [ ] localizations
- [ ] `neo_minoan` should only appear in provinces where the holder is of cretan culture in Imperator and is of `k` or `e` rank (can be implemented through new culture mapping parameters or just as a game start on-action script)