### PR TITLE
Fix FileNotFoundException when save file's basename is empty

### DIFF
--- a/ImperatorToCK3/Helpers/RakalyCaller.cs
+++ b/ImperatorToCK3/Helpers/RakalyCaller.cs
@@ -137,7 +137,7 @@ public static class RakalyCaller {
 		string savePathWithoutExtension = CommonFunctions.TrimExtension(savePath);
 		string meltedSavePath;
 		// If savePathWithoutExtension ends with a slash, it means the basename is empty.
-		if (savePathWithoutExtension.EndsWith("/") || savePathWithoutExtension.EndsWith("\\")) {
+		if (savePathWithoutExtension.EndsWith('/') || savePathWithoutExtension.EndsWith('\\')) {
 			meltedSavePath = savePathWithoutExtension + "melted.rome";
 		} else {
 			meltedSavePath = savePathWithoutExtension + "_melted.rome";


### PR DESCRIPTION
Sentry event ID: 17ff4c14bd9549eba85c8ac4b2454551