### PR TITLE
Don't warn about undefined CoA when dynamic CoA extraction is skipped

### DIFF
--- a/ImperatorToCK3.UnitTests/Mappers/Coa/CoaMapperTests.cs
+++ b/ImperatorToCK3.UnitTests/Mappers/Coa/CoaMapperTests.cs
@@ -83,16 +83,16 @@ public sealed class CoaMapperTests {
 	            }
             }";
 		Assert.Equal(coa1.Split('\n').Length,
-			coaMapper.GetCoaForFlagName("e_IRTOCK3_ADI")!.Split('\n').Length);
+			coaMapper.GetCoaForFlagName("e_IRTOCK3_ADI", warnIfMissing: false)!.Split('\n').Length);
 		Assert.Equal(coa2.Split('\n').Length,
-			coaMapper.GetCoaForFlagName("e_IRTOCK3_AMK")!.Split('\n').Length);
+			coaMapper.GetCoaForFlagName("e_IRTOCK3_AMK", warnIfMissing: false)!.Split('\n').Length);
 		Assert.Equal(coa3.Split('\n').Length,
-			coaMapper.GetCoaForFlagName("e_IRTOCK3_ANG")!.Split('\n').Length);
+			coaMapper.GetCoaForFlagName("e_IRTOCK3_ANG", warnIfMissing: false)!.Split('\n').Length);
 	}
 
 	[Fact]
 	public void GetCoaForFlagNameReturnsNullOnNonMatch() {
 		var coaMapper = new CoaMapper(imperatorModFs);
-		Assert.Null(coaMapper.GetCoaForFlagName("e_IRTOCK3_WRONG"));
+		Assert.Null(coaMapper.GetCoaForFlagName("e_IRTOCK3_WRONG", warnIfMissing: false));
 	}
 }

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -239,7 +239,8 @@ internal sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 
 		// Determine CoA.
 		if (IsCreatedFromImperator || !config.UseCK3Flags) {
-			CoA = coaMapper.GetCoaForFlagName(ImperatorCountry.Flag);
+			bool warnIfMissing = !config.SkipDynamicCoAExtraction;
+			CoA = coaMapper.GetCoaForFlagName(ImperatorCountry.Flag, warnIfMissing);
 		}
 
 		// Determine other attributes:

--- a/ImperatorToCK3/Mappers/CoA/CoaMapper.cs
+++ b/ImperatorToCK3/Mappers/CoA/CoaMapper.cs
@@ -35,10 +35,6 @@ internal sealed class CoaMapper {
 		}
 	}
 
-	public string? GetCoaForFlagName(string flagName) {
-		return GetCoaForFlagName(flagName, warnIfMissing: true);
-	}
-
 	public string? GetCoaForFlagName(string flagName, bool warnIfMissing) {
 		if (!coasMap.TryGetValue(flagName, out string? value)) {
 			if (warnIfMissing) {


### PR DESCRIPTION
closes #2566 