### PR TITLE
Allow the installer to run on Arm64-based Windows 11 via emulation

### DIFF
--- a/ImperatorToCK3.iss
+++ b/ImperatorToCK3.iss
@@ -33,10 +33,10 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesInstallIn64BitMode=x64compatible
 
 ; keep the next line if you want to prevent Setup from running on 32-bit Windows
-ArchitecturesAllowed=x64
+ArchitecturesAllowed=x64compatible
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
https://jrsoftware.org/ishelp/index.php?topic=archidentifiers