### PR TITLE
Disable CETCompat in project settings

### DIFF
--- a/ImperatorToCK3/ImperatorToCK3.csproj
+++ b/ImperatorToCK3/ImperatorToCK3.csproj
@@ -7,6 +7,7 @@
         <RuntimeIdentifiers>win-x64;linux-x64;osx-arm64</RuntimeIdentifiers>
         <ApplicationIcon>thumbnail.ico</ApplicationIcon>
         <LangVersion>13</LangVersion>
+        <CETCompat>false</CETCompat> <!-- see https://github.com/ParadoxGameConverters/ImperatorToCK3/issues/2638 -->
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Set CETCompat to false in ImperatorToCK3.csproj to address compatibility concerns as referenced in issue #2638.

closes #2638 