### PR TITLE
Improve fallback logic for generating successors' names

### DIFF
--- a/ImperatorToCK3/CK3/Characters/CharacterCollection.cs
+++ b/ImperatorToCK3/CK3/Characters/CharacterCollection.cs
@@ -713,10 +713,14 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 			if (cultureId is not null) {
 				maleNames = cultureIdToMaleNames[cultureId];
 			} else {
-				Logger.Warn($"Failed to find male names for successors of {oldCharacter.Id}.");
-				maleNames = ["Alexander"];
+				Logger.Debug($"Failed to find male names for successors of {oldCharacter.Id}.");
+				if (oldCharacter.Female) {
+					maleNames = [oldCharacter.Father?.GetName(ck3BookmarkDate) ?? "Alexander"];
+				} else {
+					maleNames = [oldCharacter.GetName(ck3BookmarkDate) ?? "Alexander"];
+				}
 			}
-			
+
 			var randomSeedForCharacter = randomSeed ^ (oldCharacter.ImperatorCharacter?.Id ?? 0);
 			var random = new Random((int)randomSeedForCharacter);
 


### PR DESCRIPTION
Fallback now uses the father's name for female characters and the character's own name for male characters, only defaulting to 'Alexander' if unavailable.