### PR TITLE
Add checks for unsupported CK3 mod combinations

### DIFF
--- a/ImperatorToCK3.UnitTests/ConfigurationTests.cs
+++ b/ImperatorToCK3.UnitTests/ConfigurationTests.cs
@@ -1,0 +1,35 @@
+using commonItems.Mods;
+using ImperatorToCK3.Exceptions;
+using Xunit;
+
+namespace ImperatorToCK3.UnitTests;
+
+public class ConfigurationTests {
+	[Fact]
+	public void DetectSpecificCK3ModsThrowsExceptionForUnsupportedModCombinations() {
+		const string tfeName = "The Fallen Eagle";
+		const string wtwsmsName = "When the World Stopped Making Sense";
+		const string roaName = "Rajas of Asia";
+		const string aepName = "Asia Expansion Project";
+		
+		var tfeMod = new Mod(tfeName, "", dependencies: []);
+		var wtwsmsMod = new Mod(wtwsmsName, "", dependencies: []);
+		var roaMod = new Mod(roaName, "", dependencies: []);
+		var aepMod = new Mod(aepName, "", dependencies: []);
+		
+		var ex = Assert.Throws<UserErrorException>(() => new Configuration().DetectSpecificCK3Mods([tfeMod, wtwsmsMod]));
+		Assert.Equal("The converter doesn't support combining The Fallen Eagle with When the World Stopped Making Sense!",
+			ex.Message);
+		
+		ex = Assert.Throws<UserErrorException>(() => new Configuration().DetectSpecificCK3Mods([roaMod, aepMod]));
+		Assert.Equal("The converter doesn't support combining Rajas of Asia with Asia Expansion Project!",
+			ex.Message);
+		
+		ex = Assert.Throws<UserErrorException>(() => new Configuration().DetectSpecificCK3Mods([tfeMod, roaMod]));
+		Assert.Equal("The converter doesn't support combining The Fallen Eagle with Rajas of Asia!", ex.Message);
+		
+		ex = Assert.Throws<UserErrorException>(() => new Configuration().DetectSpecificCK3Mods([tfeMod, aepMod]));
+		Assert.Equal("The converter doesn't support combining The Fallen Eagle with Asia Expansion Project!",
+			ex.Message);
+	}
+}

--- a/ImperatorToCK3/Configuration.cs
+++ b/ImperatorToCK3/Configuration.cs
@@ -342,6 +342,23 @@ public sealed class Configuration {
 			AsiaExpansionProjectEnabled = true;
 			Logger.Info($"AEP detected: {aepMod.Name}");
 		}
+
+		ThrowUserErrorExceptionForUnsupportedModCombinations();
+	}
+
+	private void ThrowUserErrorExceptionForUnsupportedModCombinations() {
+		if (FallenEagleEnabled && WhenTheWorldStoppedMakingSenseEnabled) {
+			throw new UserErrorException("The converter doesn't support combining The Fallen Eagle with When the World Stopped Making Sense!");
+		}
+		if (RajasOfAsiaEnabled && AsiaExpansionProjectEnabled) {
+			throw new UserErrorException("The converter doesn't support combining Rajas of Asia with Asia Expansion Project!");
+		}
+		if (FallenEagleEnabled && RajasOfAsiaEnabled) {
+			throw new UserErrorException("The converter doesn't support combining The Fallen Eagle with Rajas of Asia!");
+		}
+		if (FallenEagleEnabled && AsiaExpansionProjectEnabled) {
+			throw new UserErrorException("The converter doesn't support combining The Fallen Eagle with Asia Expansion Project!");
+		}
 	}
 
 	/// <summary>Returns a collection of CK3 mod flags with values based on the enabled mods. "vanilla" flag is set to true if no other flags are set.</summary>


### PR DESCRIPTION
Introduced validation in Configuration to throw UserErrorException when unsupported mod combinations are detected. Added unit tests to verify exceptions are thrown for specific mod pairs.

Sentry event ID: 0e82de74ff304d16bd8277e049a4f1a6