### PR TITLE
Improve the verification of CK3 Mod Directory

### DIFF
--- a/ImperatorToCK3/Configuration.cs
+++ b/ImperatorToCK3/Configuration.cs
@@ -256,7 +256,18 @@ internal sealed class Configuration {
 		if (!Directory.Exists(CK3ModsPath)) {
 			throw new UserErrorException($"{CK3ModsPath} does not exist!");
 		}
-		
+
+		var normalizedCK3ModsPath = Path.TrimEndingDirectorySeparator(
+			CK3ModsPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+		);
+		var expectedSuffix = Path.Combine("Paradox Interactive", "Crusader Kings III", "mod");
+		var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+			? StringComparison.OrdinalIgnoreCase
+			: StringComparison.Ordinal;
+		if (!normalizedCK3ModsPath.EndsWith(expectedSuffix, comparison)) {
+			throw new UserErrorException($"{CK3ModsPath} is not a valid CK3 mods directory! It should end with {expectedSuffix}.");
+		}
+
 		// If the mods folder contains any files, at least one on them should have a .mod extension.
 		var filesInFolder = Directory.GetFiles(CK3ModsPath);
 		if (filesInFolder.Length > 0) {


### PR DESCRIPTION
Added logic to verify that CK3ModsPath points to the standard Crusader Kings III mods directory, including handling trailing separators and platform-specific path comparisons. Introduced unit tests to ensure correct validation and error handling for both valid and invalid paths.

Sentry event ID: 2bfcd84eccba4d66ba420aba627f2d05