### PR TITLE
Fix exception while cleaning up title history

### DIFF
--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -494,7 +494,9 @@ internal sealed partial class Title {
 						liegeTitle.History.Fields.TryGetValue("holder", out var liegeHolderField);
 						Date? laterDate = liegeHolderField?.DateToEntriesDict
 							.Where(kvp => kvp.Key > date && kvp.Key <= ck3BookmarkDate && kvp.Value.Count != 0 && kvp.Value[^1].Value.ToString() != "0")
-							.Min(kvp => kvp.Key);
+							.OrderBy(kvp => kvp.Key)
+							.Select(kvp => (Date?)kvp.Key)
+							.FirstOrDefault(defaultValue: null);
 
 						if (laterDate == null) {
 							liegeField.DateToEntriesDict.Remove(date);


### PR DESCRIPTION
Replaces Min with OrderBy and FirstOrDefault to select the next valid liege holder date. This improves clarity and ensures correct handling when no suitable date is found.

Sentry event ID: 01dbd4dd5e304085a73bc3550e5526f3