### PR TITLE
Fix exception when provided CK3 mods folder path ends with a slash

### DIFF
--- a/ImperatorToCK3.UnitTests/ConfigurationTests.cs
+++ b/ImperatorToCK3.UnitTests/ConfigurationTests.cs
@@ -1,3 +1,4 @@
+using commonItems;
 using commonItems.Exceptions;
 using commonItems.Mods;
 using System;
@@ -8,6 +9,60 @@ using Xunit;
 namespace ImperatorToCK3.UnitTests;
 
 public class ConfigurationTests {
+	[Fact]
+	public void TrailingSlashesAreTrimmedFromProvidedPaths() {
+		const string configurationPath = "configuration.txt";
+		var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+		var imperatorPath = Path.Combine(tempRoot, "imperator");
+		var imperatorDocPath = Path.Combine(tempRoot, "imperator_docs");
+		var ck3Path = Path.Combine(tempRoot, "ck3");
+		var ck3ModsPath = Path.Combine(tempRoot, "Paradox Interactive", "Crusader Kings III", "mod");
+
+		Directory.CreateDirectory(Path.Combine(imperatorPath, "binaries"));
+		Directory.CreateDirectory(Path.Combine(imperatorPath, "launcher"));
+		Directory.CreateDirectory(Path.Combine(imperatorDocPath, "mod"));
+		Directory.CreateDirectory(Path.Combine(ck3Path, "binaries"));
+		Directory.CreateDirectory(Path.Combine(ck3Path, "launcher"));
+		Directory.CreateDirectory(ck3ModsPath);
+
+		var imperatorExeName = OperatingSystem.IsWindows() ? "imperator.exe" : "imperator";
+		var ck3ExeName = OperatingSystem.IsWindows() ? "ck3.exe" : "ck3";
+		File.WriteAllText(Path.Combine(imperatorPath, "binaries", imperatorExeName), "");
+		File.WriteAllText(Path.Combine(ck3Path, "binaries", ck3ExeName), "");
+		File.WriteAllText(Path.Combine(imperatorPath, "launcher", "launcher-settings.json"), "{\"version\":\"2.0.4\"}");
+		File.WriteAllText(Path.Combine(ck3Path, "launcher", "launcher-settings.json"), "{\"version\":\"1.15.0\"}");
+
+		var imperatorPathForConfig = imperatorPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		var imperatorDocPathForConfig = imperatorDocPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		var ck3PathForConfig = ck3Path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		var ck3ModsPathForConfig = ck3ModsPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+		var imperatorPathWithTrailingSlash = imperatorPathForConfig + Path.AltDirectorySeparatorChar;
+		var imperatorDocPathWithTrailingSlash = imperatorDocPathForConfig + Path.AltDirectorySeparatorChar;
+		var ck3PathWithTrailingSlash = ck3PathForConfig + Path.AltDirectorySeparatorChar;
+		var ck3ModsPathWithTrailingSlash = ck3ModsPathForConfig + Path.AltDirectorySeparatorChar;
+		
+		try {
+			string content =
+				$"ImperatorDirectory = \"{imperatorPathWithTrailingSlash}\"{Environment.NewLine}" +
+				$"ImperatorDocDirectory = \"{imperatorDocPathWithTrailingSlash}\"{Environment.NewLine}" +
+				$"CK3directory = \"{ck3PathWithTrailingSlash}\"{Environment.NewLine}" +
+				$"targetGameModPath = \"{ck3ModsPathWithTrailingSlash}\"{Environment.NewLine}";
+
+			File.WriteAllText(configurationPath, content);
+			var config = new Configuration(new ConverterVersion());
+
+			Assert.Equal(imperatorPathForConfig, config.ImperatorPath);
+			Assert.Equal(imperatorDocPathForConfig, config.ImperatorDocPath);
+			Assert.Equal(ck3PathForConfig, config.CK3Path);
+			Assert.Equal(ck3ModsPathForConfig, config.CK3ModsPath);
+		}
+		finally {
+			File.Delete(configurationPath);
+			Directory.Delete(tempRoot, recursive: true);
+		}
+	}
+
 	[Fact]
 	public void DetectSpecificCK3ModsThrowsExceptionForUnsupportedModCombinations() {
 		const string tfeName = "The Fallen Eagle";

--- a/ImperatorToCK3/CommonUtils/PathHelper.cs
+++ b/ImperatorToCK3/CommonUtils/PathHelper.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace ImperatorToCK3.CommonUtils;
+
+internal static class PathHelper {
+	internal static string RemoveTrailingSeparators(string path) {
+		if (string.IsNullOrEmpty(path))
+			return path;
+
+		string root = Path.GetPathRoot(path) ?? string.Empty;
+		string trimmed = path.TrimEnd(
+			Path.DirectorySeparatorChar,
+			Path.AltDirectorySeparatorChar
+		);
+
+		return trimmed.Length == 0 ? root : trimmed;
+	}
+}

--- a/ImperatorToCK3/Configuration.cs
+++ b/ImperatorToCK3/Configuration.cs
@@ -2,6 +2,7 @@
 using commonItems.Collections;
 using commonItems.Exceptions;
 using commonItems.Mods;
+using ImperatorToCK3.CommonUtils;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -65,10 +66,10 @@ internal sealed class Configuration {
 			SaveGamePath = reader.GetString();
 			Logger.Info($"Save game set to: {SaveGamePath}");
 		});
-		parser.RegisterKeyword("ImperatorDirectory", reader => ImperatorPath = reader.GetString());
-		parser.RegisterKeyword("ImperatorDocDirectory", reader => ImperatorDocPath = reader.GetString());
-		parser.RegisterKeyword("CK3directory", reader => CK3Path = reader.GetString());
-		parser.RegisterKeyword("targetGameModPath", reader => CK3ModsPath = reader.GetString());
+		parser.RegisterKeyword("ImperatorDirectory", reader => ImperatorPath = PathHelper.RemoveTrailingSeparators(reader.GetString()));
+		parser.RegisterKeyword("ImperatorDocDirectory", reader => ImperatorDocPath = PathHelper.RemoveTrailingSeparators(reader.GetString()));
+		parser.RegisterKeyword("CK3directory", reader => CK3Path = PathHelper.RemoveTrailingSeparators(reader.GetString()));
+		parser.RegisterKeyword("targetGameModPath", reader => CK3ModsPath = PathHelper.RemoveTrailingSeparators(reader.GetString()));
 		parser.RegisterKeyword("selectedMods", reader => {
 			SelectedCK3Mods.Clear();
 			SelectedCK3Mods.UnionWith(reader.GetStrings());


### PR DESCRIPTION
Sentry event ID: ee16bf8bb8054f129d71436dbddfc861