### PR TITLE
Remove Task.Run wrapper for OutputHouses

### DIFF
--- a/ImperatorToCK3/Outputter/DynastiesOutputter.cs
+++ b/ImperatorToCK3/Outputter/DynastiesOutputter.cs
@@ -39,7 +39,7 @@ internal static class DynastiesOutputter {
 	public static async Task OutputDynastiesAndHouses(string outputModPath, DynastyCollection dynasties, HouseCollection houses) {
 		await Task.WhenAll(
 			OutputDynasties(outputModPath, dynasties),
-			Task.Run(() => OutputHouses(outputModPath, houses))
+			OutputHouses(outputModPath, houses)
 		);
 
 		Logger.IncrementProgress();


### PR DESCRIPTION
Pass OutputHouses directly into Task.WhenAll instead of wrapping it in Task.Run. This removes an unnecessary thread-pool scheduling step, simplifies the async flow, and ensures exceptions/contexts propagate naturally while keeping the original concurrent await behavior.