### PR TITLE
Skip build job for PR open/synchronize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
 
 jobs:
   build:
+    # Avoid running this job if the upload_dev_build_artifact job is going to run,
+    # since it will build the same code and we don't want to waste resources building twice.
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'opened' && github.event.action != 'synchronize') }}
     strategy:
       matrix:
         os: [[self-hosted, windows], [self-hosted, linux], macos-14]


### PR DESCRIPTION
Add an if condition to the build job in .github/workflows/build.yml to skip running for pull_request events when the action is 'opened' or 'synchronize'. This prevents duplicate builds when the upload_dev_build_artifact job will run for those PR events and conserves CI resources.