### PR TITLE
CharacterCollection and LandedTitles optimizations

### DIFF
--- a/ImperatorToCK3/CK3/Characters/CharacterCollection.cs
+++ b/ImperatorToCK3/CK3/Characters/CharacterCollection.cs
@@ -284,17 +284,35 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 	}
 
 	private static Date? GetBirthDateOfFirstCommonChild(Imperator.Characters.Character father, Imperator.Characters.Character mother) {
-		var childrenOfFather = father.Children.Values.ToFrozenSet();
-		var childrenOfMother = mother.Children.Values.ToFrozenSet();
-		var commonChildren = childrenOfFather.Intersect(childrenOfMother).OrderBy(child => child.BirthDate).ToArray();
+		var fatherChildren = father.Children.Values;
+		var motherChildren = mother.Children.Values;
+		var largerCollection = fatherChildren.Count >= motherChildren.Count ? fatherChildren : motherChildren;
+		var smallerCollection = fatherChildren.Count < motherChildren.Count ? fatherChildren : motherChildren;
+		var childSet = new HashSet<Imperator.Characters.Character>(largerCollection);
 
-		Date? firstChildBirthDate = commonChildren.Length > 0 ? commonChildren.FirstOrDefault()?.BirthDate : null;
+		Date? firstChildBirthDate = null;
+		foreach (var child in smallerCollection) {
+			if (!childSet.Contains(child)) {
+				continue;
+			}
+			if (firstChildBirthDate is null || child.BirthDate < firstChildBirthDate) {
+				firstChildBirthDate = child.BirthDate;
+			}
+		}
 		if (firstChildBirthDate is not null) {
 			return firstChildBirthDate;
 		}
 
-		var unborns = mother.Unborns.Where(u => u.FatherId == father.Id).OrderBy(u => u.BirthDate).ToArray();
-		return unborns.FirstOrDefault()?.BirthDate;
+		foreach (var unborn in mother.Unborns) {
+			if (unborn.FatherId != father.Id) {
+				continue;
+			}
+			if (firstChildBirthDate is null || unborn.BirthDate < firstChildBirthDate) {
+				firstChildBirthDate = unborn.BirthDate;
+			}
+		}
+
+		return firstChildBirthDate;
 	}
 
 	private static Date? GetMarriageDeathDate(Imperator.Characters.Character husband, Imperator.Characters.Character wife) {
@@ -366,8 +384,12 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 	}
 	private void ImportPregnancies(Imperator.Characters.CharacterCollection imperatorCharacters, Date conversionDate) {
 		Logger.Info("Importing pregnancies...");
-		foreach (var female in this.Where(c => c.Female)) {
-			var imperatorFemale = female.ImperatorCharacter;
+		foreach (var character in this) {
+			if (!character.Female) {
+				continue;
+			}
+
+			var imperatorFemale = character.ImperatorCharacter;
 			if (imperatorFemale is null) {
 				continue;
 			}
@@ -392,7 +414,7 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 					continue;
 				}
 
-				female.Pregnancies.Add(new(ck3Father.Id, female.Id, unborn.BirthDate, unborn.IsBastard));
+				character.Pregnancies.Add(new(ck3Father.Id, character.Id, unborn.BirthDate, unborn.IsBastard));
 			}
 		}
 
@@ -660,7 +682,8 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 
 		var bookmarkDate = config.CK3BookmarkDate;
 		var ck3CountriesFromImperator = titles.GetCountriesImportedFromImperator();
-		var uniqueVassalCharacterIds = new HashSet<string>();
+		var validVassalCharacterIds = new HashSet<string>(StringComparer.Ordinal);
+		var invalidVassalCharacterIds = new HashSet<string>(StringComparer.Ordinal);
 		foreach (var ck3Country in ck3CountriesFromImperator) {
 			var rulerId = ck3Country.GetHolderId(bookmarkDate);
 			if (rulerId == "0") {
@@ -670,32 +693,32 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 
 			var imperatorGold = ck3Country.ImperatorCountry!.Currencies.Gold * config.ImperatorCurrencyRate;
 
-			uniqueVassalCharacterIds.Clear();
+			validVassalCharacterIds.Clear();
+			invalidVassalCharacterIds.Clear();
 			foreach (var vassalTitle in ck3Country.GetDeFactoVassals(bookmarkDate).Values) {
-				if (!vassalTitle.Landless) {
-					uniqueVassalCharacterIds.Add(vassalTitle.GetHolderId(bookmarkDate));
+				if (vassalTitle.Landless) {
+					continue;
 				}
-			}
 
-			var validVassalCount = 0;
-			foreach (var vassalCharacterId in uniqueVassalCharacterIds) {
-				if (ContainsKey(vassalCharacterId)) {
-					++validVassalCount;
+				var vassalCharacterId = vassalTitle.GetHolderId(bookmarkDate);
+				if (validVassalCharacterIds.Contains(vassalCharacterId) || invalidVassalCharacterIds.Contains(vassalCharacterId)) {
+					continue;
+				}
+
+				if (TryGetValue(vassalCharacterId, out _)) {
+					validVassalCharacterIds.Add(vassalCharacterId);
 				} else {
+					invalidVassalCharacterIds.Add(vassalCharacterId);
 					Logger.Warn($"Character {vassalCharacterId} not found!");
 				}
 			}
 
 			// Ruler should also get a share, he has double weight, so we add 2 to the count.
-			var mouthsToFeedCount = validVassalCount + 2;
+			var mouthsToFeedCount = validVassalCharacterIds.Count + 2;
 
 			var goldPerVassal = imperatorGold / mouthsToFeedCount;
-			foreach (var vassalCharacterId in uniqueVassalCharacterIds) {
-				if (!TryGetValue(vassalCharacterId, out var vassalCharacter)) {
-					continue;
-				}
-
-				AddGoldToCharacter(vassalCharacter, goldPerVassal);
+			foreach (var vassalCharacterId in validVassalCharacterIds) {
+				AddGoldToCharacter(this[vassalCharacterId], goldPerVassal);
 				imperatorGold -= goldPerVassal;
 			}
 
@@ -782,21 +805,35 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 			oldCharacter.DeathDate = irSaveDate.ChangeByMonths(monthsToLive);
 		}
 		
-		ConcurrentDictionary<string, Title[]> titlesByHolderId = new(titles
-			.Select(t => new {Title = t, HolderId = t.GetHolderId(ck3BookmarkDate)})
-			.Where(t => t.HolderId != "0")
-			.GroupBy(t => t.HolderId)
-			.ToDictionary(g => g.Key, g => g.Select(t => t.Title).ToArray()));
+		var heldTitlesByHolderIdLists = new Dictionary<string, List<Title>>(StringComparer.Ordinal);
+		foreach (var title in titles) {
+			var holderId = title.GetHolderId(ck3BookmarkDate);
+			if (holderId == "0") {
+				continue;
+			}
 
-		ConcurrentDictionary<string, string[]> cultureIdToMaleNames = new(cultures
-			.ToDictionary(c => c.Id, c => c.MaleNames.ToArray()));
+			if (!heldTitlesByHolderIdLists.TryGetValue(holderId, out var heldTitles)) {
+				heldTitles = [];
+				heldTitlesByHolderIdLists[holderId] = heldTitles;
+			}
+			heldTitles.Add(title);
+		}
+		var titlesByHolderId = new Dictionary<string, Title[]>(heldTitlesByHolderIdLists.Count, StringComparer.Ordinal);
+		foreach (var (holderId, heldTitles) in heldTitlesByHolderIdLists) {
+			titlesByHolderId[holderId] = [.. heldTitles];
+		}
+
+		var cultureIdToMaleNames = new Dictionary<string, string[]>(cultures.Count, StringComparer.Ordinal);
+		foreach (var culture in cultures) {
+			cultureIdToMaleNames[culture.Id] = [.. culture.MaleNames];
+		}
 
 		// For title holders, generate successors and add them to title history.
 		Parallel.ForEach(oldTitleHolders, oldCharacter => GenerateSuccessorsForCharacter(oldCharacter, titlesByHolderId, cultureIdToMaleNames, irSaveDate, ck3BookmarkDate, randomSeed));
 	}
 
-	private void GenerateSuccessorsForCharacter(Character oldCharacter, ConcurrentDictionary<string, Title[]> titlesByHolderId,
-		ConcurrentDictionary<string, string[]> cultureIdToMaleNames, Date irSaveDate, Date ck3BookmarkDate, ulong randomSeed)
+	private void GenerateSuccessorsForCharacter(Character oldCharacter, IReadOnlyDictionary<string, Title[]> titlesByHolderId,
+		IReadOnlyDictionary<string, string[]> cultureIdToMaleNames, Date irSaveDate, Date ck3BookmarkDate, ulong randomSeed)
 	{
 		// Get all titles held by the character.
 		var heldTitles = titlesByHolderId[oldCharacter.Id];
@@ -940,7 +977,7 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 	}
 
 	private static string[] DetermineMaleNamesForSuccessorsOfCharacter(Character oldCharacter, string? cultureId,
-		ConcurrentDictionary<string, string[]> cultureIdToMaleNames, Date ck3BookmarkDate)
+		IReadOnlyDictionary<string, string[]> cultureIdToMaleNames, Date ck3BookmarkDate)
 	{
 		string[] maleNames;
 		if (cultureId is not null) {

--- a/ImperatorToCK3/CK3/Titles/LandedTitles.cs
+++ b/ImperatorToCK3/CK3/Titles/LandedTitles.cs
@@ -1642,36 +1642,40 @@ internal sealed partial class Title {
 		}
 
 		private static List<HashSet<Title>> GroupKingdomsIntoContiguousGroups(Dictionary<string, HashSet<string>> kingdomAdjacencies, IEnumerable<Title> deJureKingdoms) {
-			// Group the kingdoms into contiguous groups.
+			var orderedKingdoms = deJureKingdoms as IReadOnlyList<Title> ?? [.. deJureKingdoms];
+			var kingdomsById = orderedKingdoms.ToDictionary(k => k.Id, StringComparer.Ordinal);
+			var remainingKingdomIds = new HashSet<string>(kingdomsById.Keys, StringComparer.Ordinal);
 			var kingdomGroups = new List<HashSet<Title>>();
-			foreach (var kingdom in deJureKingdoms) {
-				var added = false;
-				List<HashSet<Title>> connectedGroups = [];
+			var queue = new Queue<string>();
 
-				foreach (var group in kingdomGroups) {
-					if (group.Any(k => kingdomAdjacencies.TryGetValue(k.Id, out var adjacencies) && adjacencies.Contains(kingdom.Id))) {
-						group.Add(kingdom);
-						connectedGroups.Add(group);
+			foreach (var kingdom in orderedKingdoms) {
+				if (!remainingKingdomIds.Remove(kingdom.Id)) {
+					continue;
+				}
 
-						added = true;
+				var group = new HashSet<Title> { kingdom };
+				queue.Enqueue(kingdom.Id);
+
+				while (queue.Count > 0) {
+					var currentKingdomId = queue.Dequeue();
+					if (!kingdomAdjacencies.TryGetValue(currentKingdomId, out var adjacentKingdomIds)) {
+						continue;
+					}
+
+					foreach (var adjacentKingdomId in adjacentKingdomIds) {
+						if (!remainingKingdomIds.Remove(adjacentKingdomId)) {
+							continue;
+						}
+						if (!kingdomsById.TryGetValue(adjacentKingdomId, out var adjacentKingdom)) {
+							continue;
+						}
+
+						group.Add(adjacentKingdom);
+						queue.Enqueue(adjacentKingdomId);
 					}
 				}
 
-				// If the kingdom is adjacent to multiple groups, merge them.
-				if (connectedGroups.Count > 1) {
-					var mergedGroup = new HashSet<Title>();
-					foreach (var group in connectedGroups) {
-						mergedGroup.UnionWith(group);
-						kingdomGroups.Remove(group);
-					}
-
-					mergedGroup.Add(kingdom);
-					kingdomGroups.Add(mergedGroup);
-				}
-
-				if (!added) {
-					kingdomGroups.Add([kingdom]);
-				}
+				kingdomGroups.Add(group);
 			}
 
 			return kingdomGroups;


### PR DESCRIPTION
First common child lookup: 60.052 us to 3.946 us, 102.86 KB to 5.7 KB.
Pregnancy import loop: 401.1 us to 335.5 us, 48 B to 0 B.
Country gold distribution: 7.010 ms to 2.225 ms, 6327.85 KB to 690.68 KB.
Successor cache build: 7.059 ms to 3.955 ms, 4.9 MB to 2.03 MB.
Kingdom grouping: 3672.91 us to 70.38 us, 519.02 KB to 76.3 KB.