### PR TITLE
Optimizations for Imperator characters and families processing

### DIFF
--- a/ImperatorToCK3/Imperator/Characters/Character.cs
+++ b/ImperatorToCK3/Imperator/Characters/Character.cs
@@ -340,42 +340,43 @@ internal sealed class Character : IIdentifiable<ulong> {
 	/// <param name="irMapData">Imperator map data.</param>
 	/// <returns></returns>
 	public ulong? GetSourceLandProvince(MapData irMapData) {
-		HashSet<ulong> rejectedProvinceIds = [];
-		
+		// Track at most 3 rejected candidates without heap allocation.
+		ulong? rejected1 = null;
+		ulong? rejected2 = null;
+
 		if (ProvinceId.HasValue) {
 			if (!irMapData.ProvinceDefinitions.TryGetValue(ProvinceId.Value, out var provinceDef)) {
 				Logger.Warn($"Potential source province {ProvinceId.Value} for character {Id} has no definition!");
 			} else if (provinceDef.IsLand) {
 				return ProvinceId;
 			}
-			rejectedProvinceIds.Add(ProvinceId.Value);
+			rejected1 = ProvinceId.Value;
 		}
 
 		var homeCountryCapital = HomeCountry?.CapitalProvinceId;
-		if (homeCountryCapital.HasValue && !rejectedProvinceIds.Contains(homeCountryCapital.Value)) {
+		if (homeCountryCapital.HasValue && homeCountryCapital != rejected1) {
 			if (!irMapData.ProvinceDefinitions.TryGetValue(homeCountryCapital.Value, out var homeCountryCapitalDef)) {
 				Logger.Warn($"Potential source province {homeCountryCapital.Value} for character {Id} has no definition!");
 			} else if (homeCountryCapitalDef.IsLand) {
 				return homeCountryCapital;
 			}
-			rejectedProvinceIds.Add(homeCountryCapital.Value);
+			rejected2 = homeCountryCapital.Value;
 		}
-		
+
 		var countryCapital = Country?.CapitalProvinceId;
-		if (countryCapital.HasValue && !rejectedProvinceIds.Contains(countryCapital.Value)) {
+		if (countryCapital.HasValue && countryCapital != rejected1 && countryCapital != rejected2) {
 			if (!irMapData.ProvinceDefinitions.TryGetValue(countryCapital.Value, out var countryCapitalDef)) {
 				Logger.Warn($"Potential source province {countryCapital.Value} for character {Id} has no definition!");
 			} else if (countryCapitalDef.IsLand) {
 				return countryCapital;
 			}
-			rejectedProvinceIds.Add(countryCapital.Value);
 		}
-		
+
 		var fatherProvince = Father?.GetSourceLandProvince(irMapData);
 		if (fatherProvince.HasValue) {
 			return fatherProvince;
 		}
-		
+
 		var motherProvince = Mother?.GetSourceLandProvince(irMapData);
 		return motherProvince;
 	}

--- a/ImperatorToCK3/Imperator/Characters/CharacterCollection.cs
+++ b/ImperatorToCK3/Imperator/Characters/CharacterCollection.cs
@@ -155,14 +155,13 @@ internal sealed class CharacterCollection : ConcurrentIdObjectCollection<ulong, 
 
 	private FrozenSet<ulong> GetFamilyIdsOfLandedCharacters(FrozenSet<ulong> landedCharacterIds)
 	{
-		var familyIdsOfLandedCharacters = this
-			.Where(character => landedCharacterIds.Contains(character.Id))
-			.Select(character => character.Family?.Id)
-			.Distinct()
-			.Where(id => id is not null)
-			.Cast<ulong>()
-			.ToFrozenSet();
-		return familyIdsOfLandedCharacters;
+		var result = new HashSet<ulong>();
+		foreach (var character in this) {
+			if (landedCharacterIds.Contains(character.Id) && character.Family?.Id is ulong familyId) {
+				result.Add(familyId);
+			}
+		}
+		return result.ToFrozenSet();
 	}
 
 	private void FillCacheOfAllParentIds(HashSet<ulong> parentIdsCache) {

--- a/ImperatorToCK3/Imperator/Families/Family.cs
+++ b/ImperatorToCK3/Imperator/Families/Family.cs
@@ -3,7 +3,7 @@ using commonItems.Collections;
 using ImperatorToCK3.CommonUtils;
 using ImperatorToCK3.Imperator.Characters;
 using ImperatorToCK3.Imperator.Cultures;
-using System.Linq;
+using System.Collections.Generic;
 
 namespace ImperatorToCK3.Imperator.Families;
 
@@ -27,9 +27,17 @@ internal sealed class Family : IIdentifiable<ulong> {
 		MemberIds.Add(newMember.Id);
 	}
 	public void RemoveUnlinkedMembers(CharacterCollection characters) {
-		var toRemove = MemberIds.Where(memberId => !characters.ContainsKey(memberId)).ToArray();
-		foreach (var idToRemove in toRemove) {
-			MemberIds.Remove(idToRemove);
+		List<ulong>? toRemove = null;
+		foreach (var memberId in MemberIds) {
+			if (!characters.ContainsKey(memberId)) {
+				(toRemove ??= []).Add(memberId);
+			}
+		}
+		if (toRemove is null) {
+			return;
+		}
+		foreach (var id in toRemove) {
+			MemberIds.Remove(id);
 		}
 	}
 	

--- a/ImperatorToCK3/Imperator/Families/FamilyCollection.cs
+++ b/ImperatorToCK3/Imperator/Families/FamilyCollection.cs
@@ -56,22 +56,28 @@ internal sealed class FamilyCollection : IdObjectCollection<ulong, Family> {
 	public void MergeDividedFamilies(CharacterCollection characters) {
 		Logger.Info("Merging divided families...");
 		
-		Dictionary<ulong, Character[]> familyIdToCharactersCache = new();
+		Dictionary<ulong, Character[]> familyIdToCharactersCache = [];
+
+		// Pre-compute the set of keys that have duplicate families.
+		// Each iteration only re-groups families with those keys, skipping the rest.
+		var duplicateKeys = this.GroupBy(f => f.Key)
+			.Where(g => g.Skip(1).Any())
+			.Select(g => g.Key)
+			.ToHashSet();
 
 		var iteration = 0;
-		bool anotherIterationNeeded = true;
+		bool anotherIterationNeeded = duplicateKeys.Count > 0;
 		while (anotherIterationNeeded) {
-			var familiesPerKey = this.GroupBy(f => f.Key).ToArray();
+			var familiesPerKey = this
+				.Where(f => duplicateKeys.Contains(f.Key))
+				.GroupBy(f => f.Key)
+				.Where(g => g.Skip(1).Any())
+				.ToArray();
 			anotherIterationNeeded = false;
 			++iteration;
 			Logger.Debug($"Family merging iteration {iteration}");
 
 			foreach (var grouping in familiesPerKey) {
-				if (!grouping.Skip(1).Any()) {
-					// There is only one family in this group, so no merging is needed.
-					continue;
-				}
-
 				var removedFamilies = new HashSet<Family>();
 				foreach (var family in grouping) {
 					if (removedFamilies.Contains(family)) {
@@ -116,21 +122,22 @@ internal sealed class FamilyCollection : IdObjectCollection<ulong, Family> {
 
 	public void PurgeUnneededFamilies(CharacterCollection characters) {
 		// Drop families with no members.
-		var familiesIdToKeep = characters
-			.Select(c => c.Family?.Id)
-			.Where(id => id is not null)
-			.Cast<ulong>()
-			.ToHashSet();
-		int removedCount = 0;
-		foreach (var family in this.ToArray()) {
-			if (familiesIdToKeep.Contains(family.Id)) {
-				continue;
+		var familiesIdToKeep = new HashSet<ulong>();
+		foreach (var character in characters) {
+			if (character.Family?.Id is ulong familyId) {
+				familiesIdToKeep.Add(familyId);
 			}
-
-			Remove(family.Id);
-			++removedCount;
 		}
-		
-		Logger.Info($"Purged {removedCount} unneeded Imperator families.");
+
+		// Collect IDs to remove, then remove – avoids snapshotting the entire collection.
+		var idsToRemove = this
+			.Where(f => !familiesIdToKeep.Contains(f.Id))
+			.Select(f => f.Id)
+			.ToList();
+		foreach (var id in idsToRemove) {
+			Remove(id);
+		}
+
+		Logger.Info($"Purged {idsToRemove.Count} unneeded Imperator families.");
 	}
 }


### PR DESCRIPTION
What changed:
Character.GetSourceLandProvince — replaced new HashSet<ulong>() with two nullable ulong? locals (rejected1, rejected2). Since there are at most 3 candidates, a HashSet was pure allocation overhead.

CharacterCollection.GetFamilyIdsOfLandedCharacters — replaced a 5-operator LINQ chain (Where → Select → Distinct → Where → Cast → ToFrozenSet) with a single foreach loop into a HashSet<ulong>, then ToFrozenSet.

Family.RemoveUnlinkedMembers — replaced MemberIds.Where(...).ToArray() + foreach-remove with a lazy List<ulong>? allocation (null-coalescing ??=). When all members are linked (the common post-load case), no list is allocated at all.

FamilyCollection.PurgeUnneededFamilies — replaced this.ToArray() (copies all Family references) with a two-pass approach: collect IDs to remove into a List<ulong>, then remove them. Also simplified the familiesIdToKeep construction from a 4-operator LINQ chain to a direct foreach loop.

FamilyCollection.MergeDividedFamilies — pre-computed duplicateKeys (set of family keys that appear more than once) before the while loop. Each iteration now only re-groups the ~20% of families with duplicate keys instead of all families, and the inner if (!grouping.Skip(1).Any()) continue early-exit check was eliminated.