### PR TITLE
Optimizations for characters, dynasties, titles and families processing

### DIFF
--- a/ImperatorToCK3/CK3/Characters/CharacterCollection.cs
+++ b/ImperatorToCK3/CK3/Characters/CharacterCollection.cs
@@ -576,11 +576,13 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 		var charactersToCheck = charactersToCheckList.ToArray();
 
 		// Members of landed dynasties will be preserved, unless dead and childless.
-		var dynastyIdsOfLandedCharacters = landedCharacters
-			.Select(character => character.GetDynastyId(ck3BookmarkDate))
-			.Distinct()
-			.Where(id => id is not null)
-			.ToFrozenSet();
+		var dynastyIdsOfLandedCharacters = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var landedCharacter in landedCharacters) {
+			var dynastyId = landedCharacter.GetDynastyId(ck3BookmarkDate);
+			if (dynastyId is not null) {
+				dynastyIdsOfLandedCharacters.Add(dynastyId);
+			}
+		}
 
 		int i = 0;
 		var charactersToRemove = new List<Character>();
@@ -601,8 +603,14 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 
 			Logger.Debug($"\tPurged {charactersToRemove.Count} unneeded characters in iteration {i}.");
 			if (charactersToRemove.Count > 0) {
-				var removedIds = removedCharacterIds.ToFrozenSet();
-				charactersToCheck = [.. charactersToCheck.Where(character => !removedIds.Contains(character.Id))];
+				var removedIds = new HashSet<string>(removedCharacterIds, StringComparer.Ordinal);
+				var filteredCharacters = new List<Character>(charactersToCheck.Length - removedIds.Count);
+				foreach (var character in charactersToCheck) {
+					if (!removedIds.Contains(character.Id)) {
+						filteredCharacters.Add(character);
+					}
+				}
+				charactersToCheck = [.. filteredCharacters];
 			}
 		} while (charactersToRemove.Count > 0);
 
@@ -614,13 +622,14 @@ internal sealed partial class CharacterCollection : ConcurrentIdObjectCollection
 	}
 
 	private static void DetermineCharactersToPurge(List<Character> charactersToRemove, IEnumerable<Character> charactersToCheck,
-		FrozenSet<string?> dynastyIdsOfLandedCharacters, HashSet<string> parentIdsCache, Date ck3BookmarkDate)
+		HashSet<string> dynastyIdsOfLandedCharacters, HashSet<string> parentIdsCache, Date ck3BookmarkDate)
 	{
 		// See who can be removed.
 		charactersToRemove.Clear();
 		foreach (var character in charactersToCheck) {
 			// Does the character belong to a dynasty that holds or held titles?
-			if (dynastyIdsOfLandedCharacters.Contains(character.GetDynastyId(ck3BookmarkDate))) {
+			var dynastyId = character.GetDynastyId(ck3BookmarkDate);
+			if (dynastyId is not null && dynastyIdsOfLandedCharacters.Contains(dynastyId)) {
 				// Is the character dead and childless? Purge.
 				if (!parentIdsCache.Contains(character.Id)) {
 					charactersToRemove.Add(character);

--- a/ImperatorToCK3/CK3/Dynasties/DynastyCollection.cs
+++ b/ImperatorToCK3/CK3/Dynasties/DynastyCollection.cs
@@ -5,6 +5,7 @@ using commonItems.Mods;
 using ImperatorToCK3.CK3.Characters;
 using ImperatorToCK3.CK3.Titles;
 using ImperatorToCK3.Mappers.Culture;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -147,35 +148,56 @@ internal sealed class DynastyCollection : ConcurrentIdObjectCollection<string, D
 		Logger.Info("Flattening dynasties with no founders...");
 		int count = 0;
 		
-		var charactersWithDynastyIds = characters
-			.Select(c => (c, c.GetDynastyId(date)))
-			.Where(c => c.Item2 is not null)
-			.Select(c => (c.c, c.Item2!))
-			.ToArray();
-		var charactersWithHouseIds = characters
-			.Select(c => (c, c.GetDynastyHouseId(date)))
-			.Where(c => c.Item2 is not null)
-			.Select(c => (c.c, c.Item2!))
-			.ToArray();
+		var dynastiesWithMainBranchMembers = new HashSet<string>(StringComparer.Ordinal);
+		var charactersByHouseId = new Dictionary<string, List<Character>>(StringComparer.Ordinal);
+		foreach (var character in characters) {
+			var dynastyId = character.GetDynastyId(date);
+			if (dynastyId is not null) {
+				dynastiesWithMainBranchMembers.Add(dynastyId);
+			}
+
+			var houseId = character.GetDynastyHouseId(date);
+			if (houseId is null) {
+				continue;
+			}
+
+			if (!charactersByHouseId.TryGetValue(houseId, out var houseMembers)) {
+				houseMembers = [];
+				charactersByHouseId[houseId] = houseMembers;
+			}
+			houseMembers.Add(character);
+		}
+
+		var houseIdsByDynasty = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+		foreach (var house in houses) {
+			if (house.DynastyId is not string dynastyId) {
+				continue;
+			}
+
+			if (!houseIdsByDynasty.TryGetValue(dynastyId, out var dynastyHouseIds)) {
+				dynastyHouseIds = [];
+				houseIdsByDynasty[dynastyId] = dynastyHouseIds;
+			}
+			dynastyHouseIds.Add(house.Id);
+		}
 		
 		foreach (var dynasty in this) {
-			var mainBranchMembers = charactersWithDynastyIds
-				.Where(c => c.Item2 == dynasty.Id)
-				.ToArray();
-			if (mainBranchMembers.Length > 0) {
+			if (dynastiesWithMainBranchMembers.Contains(dynasty.Id)) {
 				continue;
 			}
 			
-			var dynastyHouseIds = houses
-				.Where(h => h.DynastyId == dynasty.Id)
-				.Select(h => h.Id)
-				.ToArray();
-			var cadetHouseMembers = charactersWithHouseIds
-				.Where(c => dynastyHouseIds.Contains(c.Item2))
-				.Select(c => c.c)
-				.ToArray();
-			
-			if (cadetHouseMembers.Length == 0) {
+			if (!houseIdsByDynasty.TryGetValue(dynasty.Id, out var dynastyHouseIds)) {
+				continue;
+			}
+
+			var cadetHouseMembers = new List<Character>();
+			foreach (var houseId in dynastyHouseIds) {
+				if (charactersByHouseId.TryGetValue(houseId, out var members)) {
+					cadetHouseMembers.AddRange(members);
+				}
+			}
+
+			if (cadetHouseMembers.Count == 0) {
 				continue;
 			}
 			

--- a/ImperatorToCK3/CK3/Titles/Title.cs
+++ b/ImperatorToCK3/CK3/Titles/Title.cs
@@ -1407,14 +1407,25 @@ internal sealed partial class Title : IPDXSerializable, IIdentifiable<string> {
 		}
 
 		// case: title is independent
-		var higherTitlesOfHolder = parentCollection.Where(t => t.GetHolderId(ck3BookmarkDate) == holderId && t.Rank > Rank)
-			.OrderByDescending(t => t.Rank)
-			.ToImmutableList();
-		var highestTitleRank = higherTitlesOfHolder.FirstOrDefault(defaultValue: null)?.Rank;
+		var higherTitlesOfHolder = new List<Title>();
+		TitleRank? highestTitleRank = null;
+		foreach (var title in parentCollection) {
+			if (title.GetHolderId(ck3BookmarkDate) != holderId || title.Rank <= Rank) {
+				continue;
+			}
+			higherTitlesOfHolder.Add(title);
+			if (highestTitleRank is null || title.Rank > highestTitleRank) {
+				highestTitleRank = title.Rank;
+			}
+		}
 		if (highestTitleRank is null) {
 			return null;
 		}
-		foreach (var title in higherTitlesOfHolder.Where(t => t.Rank == highestTitleRank)) {
+		foreach (var title in higherTitlesOfHolder) {
+			if (title.Rank != highestTitleRank) {
+				continue;
+			}
+
 			if (title.Rank == realmRank) {
 				return title;
 			}

--- a/ImperatorToCK3/Imperator/Characters/CharacterCollection.cs
+++ b/ImperatorToCK3/Imperator/Characters/CharacterCollection.cs
@@ -141,10 +141,18 @@ internal sealed class CharacterCollection : ConcurrentIdObjectCollection<ulong, 
 
 			Logger.Debug($"\tPurged {charactersToRemove.Count} unneeded Imperator characters in iteration {i}.");
 			if (charactersToRemove.Count > 0) {
-				var removedIds = charactersToRemove
-					.Select(character => character.Id)
-					.ToFrozenSet();
-				charactersToCheck = [.. charactersToCheck.Where(character => !removedIds.Contains(character.Id))];
+				var removedIds = new HashSet<ulong>();
+				foreach (var character in charactersToRemove) {
+					removedIds.Add(character.Id);
+				}
+
+				var filteredCharactersToCheck = new List<Character>(charactersToCheck.Length - removedIds.Count);
+				foreach (var character in charactersToCheck) {
+					if (!removedIds.Contains(character.Id)) {
+						filteredCharactersToCheck.Add(character);
+					}
+				}
+				charactersToCheck = [.. filteredCharactersToCheck];
 			}
 		} while (charactersToRemove.Count > 0);
 		

--- a/ImperatorToCK3/Imperator/Families/FamilyCollection.cs
+++ b/ImperatorToCK3/Imperator/Families/FamilyCollection.cs
@@ -60,31 +60,52 @@ internal sealed class FamilyCollection : IdObjectCollection<ulong, Family> {
 
 		// Pre-compute the set of keys that have duplicate families.
 		// Each iteration only re-groups families with those keys, skipping the rest.
-		var duplicateKeys = this.GroupBy(f => f.Key)
-			.Where(g => g.Skip(1).Any())
-			.Select(g => g.Key)
-			.ToHashSet();
+		var keyCounts = new Dictionary<string, int>();
+		foreach (var family in this) {
+			if (keyCounts.TryGetValue(family.Key, out var count)) {
+				keyCounts[family.Key] = count + 1;
+			} else {
+				keyCounts[family.Key] = 1;
+			}
+		}
+		var duplicateKeys = new HashSet<string>();
+		foreach (var (key, count) in keyCounts) {
+			if (count > 1) {
+				duplicateKeys.Add(key);
+			}
+		}
 
 		var iteration = 0;
 		bool anotherIterationNeeded = duplicateKeys.Count > 0;
 		while (anotherIterationNeeded) {
-			var familiesPerKey = this
-				.Where(f => duplicateKeys.Contains(f.Key))
-				.GroupBy(f => f.Key)
-				.Where(g => g.Skip(1).Any())
-				.ToArray();
+			var familiesPerKey = new Dictionary<string, List<Family>>();
+			foreach (var family in this) {
+				if (!duplicateKeys.Contains(family.Key)) {
+					continue;
+				}
+
+				if (!familiesPerKey.TryGetValue(family.Key, out var groupedFamilies)) {
+					groupedFamilies = [];
+					familiesPerKey[family.Key] = groupedFamilies;
+				}
+				groupedFamilies.Add(family);
+			}
 			anotherIterationNeeded = false;
 			++iteration;
 			Logger.Debug($"Family merging iteration {iteration}");
 
-			foreach (var grouping in familiesPerKey) {
+			foreach (var (groupingKey, groupingFamilies) in familiesPerKey) {
+				if (groupingFamilies.Count <= 1) {
+					continue;
+				}
+
 				var removedFamilies = new HashSet<Family>();
-				foreach (var family in grouping) {
+				foreach (var family in groupingFamilies) {
 					if (removedFamilies.Contains(family)) {
 						continue;
 					}
 					var familyMemberIds = family.MemberIds;
-					foreach (var anotherFamily in grouping) {
+					foreach (var anotherFamily in groupingFamilies) {
 						if (family.Equals(anotherFamily)) {
 							continue;
 						}
@@ -107,7 +128,7 @@ internal sealed class FamilyCollection : IdObjectCollection<ulong, Family> {
 							continue;
 						}
 
-						Logger.Debug($"Reuniting family {grouping.Key}: {anotherFamily.Id} into {family.Id}");
+						Logger.Debug($"Reuniting family {groupingKey}: {anotherFamily.Id} into {family.Id}");
 						ReuniteFamily(family, anotherFamily, anotherFamilyMembers);
 						removedFamilies.Add(anotherFamily);
 


### PR DESCRIPTION
What was changed:

- Replaced repeated LINQ grouping/filtering in MergeDividedFamilies with dictionary-based single-pass grouping per iteration.
- Reworked FlattenDynastiesWithNoFounders to indexed lookups (dynasty -> houses, house -> members) instead of repeated Select/Where/Contains scans.
- Replaced GetRealmOfRank independent branch LINQ pipeline with manual scan tracking highest rank and candidate titles.
- Replaced Imperator purge filtering from Select/ToFrozenSet/Where/ToArray to HashSet + list loop.
- Replaced CK3 purge dynasty-id collection and removed-id filtering from LINQ chains to HashSet + loop logic.