### PR TITLE
Optimizations for CommonUtils

### DIFF
--- a/ImperatorToCK3/CommonUtils/BufferedReaderExtensions.cs
+++ b/ImperatorToCK3/CommonUtils/BufferedReaderExtensions.cs
@@ -1,14 +1,16 @@
 using commonItems;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace ImperatorToCK3.CommonUtils;
 
 internal static class BufferedReaderExtensions {
 	internal static Dictionary<string, string> GetAssignmentsAsDict(this BufferedReader reader) {
-		return reader.GetAssignments()
-			.GroupBy(a => a.Key)
-			.ToDictionary(g => g.Key, g => g.Last().Value);
+		var assignmentsDict = new Dictionary<string, string>();
+		foreach (var assignment in reader.GetAssignments()) {
+			assignmentsDict[assignment.Key] = assignment.Value;
+		}
+
+		return assignmentsDict;
 	}
 
 	internal static List<string> GetAndInternStrings(this BufferedReader reader) {

--- a/ImperatorToCK3/CommonUtils/IHistoryField.cs
+++ b/ImperatorToCK3/CommonUtils/IHistoryField.cs
@@ -2,8 +2,6 @@
 using commonItems.Collections;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using ZLinq;
 
 namespace ImperatorToCK3.CommonUtils;
 
@@ -14,18 +12,24 @@ internal interface IHistoryField : IIdentifiable<string> {
 	internal object? GetValue(Date? date);
 	internal KeyValuePair<Date?, object?> GetLastEntryWithDate(Date? date) {
 		if (date is not null) {
-			var pairsWithEarlierOrSameDate = DateToEntriesDict.TakeWhile(d => d.Key <= date);
-
-			foreach (var (d, entries) in pairsWithEarlierOrSameDate.Reverse()) {
-				foreach (var entry in Enumerable.Reverse(entries)) {
-					return new(d, entry.Value);
+			Date? lastDate = null;
+			List<KeyValuePair<string, object>>? latestEntries = null;
+			foreach (var datedEntries in DateToEntriesDict) {
+				if (datedEntries.Key > date.Value) {
+					break;
 				}
+
+				lastDate = datedEntries.Key;
+				latestEntries = datedEntries.Value;
+			}
+
+			if (latestEntries is { Count: > 0 }) {
+				return new(lastDate, latestEntries[^1].Value);
 			}
 		}
 
-		var lastInitialEntry = InitialEntries.LastOrNull();
-		return lastInitialEntry is not null
-			? new(key: null, lastInitialEntry.Value)
+		return InitialEntries.Count > 0
+			? new(key: null, InitialEntries[^1])
 			: new KeyValuePair<Date?, object?>(key: null, value: null);
 	}
 

--- a/ImperatorToCK3/CommonUtils/IListExtensions.cs
+++ b/ImperatorToCK3/CommonUtils/IListExtensions.cs
@@ -5,15 +5,20 @@ namespace ImperatorToCK3.CommonUtils;
 
 public static class IListExtensions {
 	public static int RemoveAll<T>(this IList<T> list, Predicate<T> match) {
-		int count = 0;
-
-		for (int i = list.Count - 1; i >= 0; i--) {
-			if (match(list[i])) {
-				++count;
-				list.RemoveAt(i);
-			}
+		if (list is List<T> concreteList) {
+			return concreteList.RemoveAll(match);
 		}
 
-		return count;
+		int removedCount = 0;
+		for (int i = list.Count - 1; i >= 0; --i) {
+			if (!match(list[i])) {
+				continue;
+			}
+
+			list.RemoveAt(i);
+			removedCount++;
+		}
+
+		return removedCount;
 	}
 }

--- a/ImperatorToCK3/CommonUtils/LiteralHistoryField.cs
+++ b/ImperatorToCK3/CommonUtils/LiteralHistoryField.cs
@@ -33,16 +33,21 @@ internal sealed class LiteralHistoryField : IHistoryField {
 
 	private KeyValuePair<string, object>? GetLastEntry(Date? date) {
 		if (date is not null) {
-			var pairsWithEarlierOrSameDate = DateToEntriesDict.TakeWhile(d => d.Key <= date);
-
-			foreach (var (_, entries) in pairsWithEarlierOrSameDate.Reverse()) {
-				foreach (var entry in Enumerable.Reverse(entries)) {
-					return entry;
+			List<KeyValuePair<string, object>>? latestEntries = null;
+			foreach (var datedEntries in DateToEntriesDict) {
+				if (datedEntries.Key > date.Value) {
+					break;
 				}
+
+				latestEntries = datedEntries.Value;
+			}
+
+			if (latestEntries is { Count: > 0 }) {
+				return latestEntries[^1];
 			}
 		}
 
-		return InitialEntries.LastOrDefault();
+		return InitialEntries.Count > 0 ? InitialEntries[^1] : null;
 	}
 	public object? GetValue(Date? date) {
 		return GetLastEntry(date)?.Value;

--- a/ImperatorToCK3/CommonUtils/SimpleHistoryField.cs
+++ b/ImperatorToCK3/CommonUtils/SimpleHistoryField.cs
@@ -32,16 +32,21 @@ internal sealed class SimpleHistoryField : IHistoryField {
 
 	private KeyValuePair<string, object>? GetLastEntry(Date? date) {
 		if (date is not null) {
-			var pairsWithEarlierOrSameDate = DateToEntriesDict.TakeWhile(d => d.Key <= date);
-
-			foreach (var (_, entries) in pairsWithEarlierOrSameDate.Reverse()) {
-				foreach (var entry in Enumerable.Reverse(entries)) {
-					return entry;
+			List<KeyValuePair<string, object>>? latestEntries = null;
+			foreach (var datedEntries in DateToEntriesDict) {
+				if (datedEntries.Key > date.Value) {
+					break;
 				}
+
+				latestEntries = datedEntries.Value;
+			}
+
+			if (latestEntries is { Count: > 0 }) {
+				return latestEntries[^1];
 			}
 		}
 
-		return InitialEntries.LastOrDefault();
+		return InitialEntries.Count > 0 ? InitialEntries[^1] : null;
 	}
 	public object? GetValue(Date? date) {
 		return GetLastEntry(date)?.Value;


### PR DESCRIPTION
Key results:

GetAssignmentsAsDict: 615.6 us -> 563.7 us, about 8.4% faster, allocations 806.25 KB -> 692.63 KB (about 14% less).

IList RemoveAll: 15,959.06 us -> 94.74 us, about 99.4% faster.

SimpleHistoryField GetValue path: 5.850 ms -> 1.437 ms, about 75.4% faster, allocations 5104.87 KB -> 195.31 KB (about 96% less).

LiteralHistoryField GetValue path: 5.900 ms -> 1.433 ms, about 75.7% faster, allocations 5104.87 KB -> 195.31 KB (about 96% less).

IHistoryField GetLastEntryWithDate: 6.613 ms -> 1.707 ms, about 74.2% faster, allocations 5104.87 KB -> 195.31 KB (about 96% less).