### PR TITLE
Fix for the vanilla Great Moravia holder remaining on the lobby map in 867

### DIFF
--- a/ImperatorToCK3/CK3/World.cs
+++ b/ImperatorToCK3/CK3/World.cs
@@ -340,7 +340,6 @@ internal sealed class World {
 		ImportImperatorHoldingsIfNotDisabledByConfiguration(impWorld, config);
 
 		LandedTitles.ImportDevelopmentFromImperator(Provinces, CorrectedDate, config.ImperatorCivilizationWorth);
-		LandedTitles.RemoveInvalidLandlessTitles(config.CK3BookmarkDate);
 
 		// Apply region-specific tweaks.
 		HandleIcelandAndFaroeIslands(impWorld, config);
@@ -352,6 +351,8 @@ internal sealed class World {
 
 		// Now that Islam has been handled, we can generate filler holders without the risk of making them Muslim.
 		GenerateFillerHoldersForUnownedLands(impWorld.Provinces, Cultures, config);
+		// The filler holders have overwritten some counties, so now we can remove holders from titles that have become landless.
+		LandedTitles.RemoveInvalidLandlessTitles(config.CK3BookmarkDate);
 		Logger.IncrementProgress();
 		if (!config.StaticDeJure) {
 			LandedTitles.SetDeJureKingdomsAndAbove(config.CK3BookmarkDate, Cultures, Characters, MapData, CK3RegionMapper, LocDB);
@@ -1349,10 +1350,12 @@ internal sealed class World {
 
 				duchy.SetHolder(holder, date);
 				duchy.SetGovernment(government, date);
+				duchy.SetDeFactoLiege(newLiege: null, date);
 				duchyIdToHolderDict[duchy.Id] = holder;
 			} else {
 				county.SetGovernment(government, date);
 			}
+			county.SetDeFactoLiege(newLiege: null, date);
 		}
 	}
 

--- a/ImperatorToCK3/Data_Files/configurables/title_map.txt
+++ b/ImperatorToCK3/Data_Files/configurables/title_map.txt
@@ -102,8 +102,6 @@ link = { ir = BMY ck3 = k_blemmyia rank = k }
 link = { ir = HVT ck3 = k_switzerland rank = k }
 
 #Illyria and Dacia
-
-link = { ir = OTN ck3 = k_moravia rank = k }
 link = { ir = TYR ck3 = k_moldavia rank = k }
 link = { ir = NRC ck3 = k_austria rank = k }
 


### PR DESCRIPTION
Also removed a mapping which doesn't make sense to me, Cotinians were not Moravians.